### PR TITLE
Fix Struct Instance Emission Logic

### DIFF
--- a/programa_opt.ll
+++ b/programa_opt.ll
@@ -1,10 +1,6 @@
 ; ModuleID = 'programa.ll'
 source_filename = "programa.ll"
 
-%Set_int = type { ptr }
-%Set_boolean = type { ptr }
-%Set_string = type { ptr }
-
 @.strChar = private constant [3 x i8] c"%c\00"
 @.strTrue = private constant [6 x i8] c"true\0A\00"
 @.strFalse = private constant [7 x i8] c"false\0A\00"
@@ -13,7 +9,9 @@ source_filename = "programa.ll"
 @.strFloat = private constant [4 x i8] c"%f\0A\00"
 @.strStr = private constant [4 x i8] c"%s\0A\00"
 @.strEmpty = private constant [1 x i8] zeroinitializer
-@.str0 = private constant [5 x i8] c"zard\00"
+@.str0 = private constant [4 x i8] c"---\00"
+@.str1 = private constant [8 x i8] c"Matriz:\00"
+@.str2 = private constant [12 x i8] c"Soma total:\00"
 
 declare i32 @printf(ptr, ...)
 
@@ -47,24 +45,6 @@ declare void @arraylist_print_ptr(ptr, ptr)
 
 declare void @removeItem(ptr, i64)
 
-declare ptr @arraylist_create_bool(i64)
-
-declare void @arraylist_add_bool(ptr, i1)
-
-declare void @arraylist_addAll_bool(ptr, ptr, i64)
-
-declare void @arraylist_print_bool(ptr)
-
-declare void @arraylist_clear_bool(ptr)
-
-declare void @arraylist_remove_bool(ptr, i64)
-
-declare void @arraylist_free_bool(ptr)
-
-declare i1 @arraylist_get_bool(ptr, i64, ptr)
-
-declare i32 @arraylist_size_bool(ptr)
-
 declare ptr @arraylist_create_int(i64)
 
 declare void @arraylist_add_int(ptr, i32)
@@ -83,245 +63,202 @@ declare void @arraylist_remove_int(ptr, i64)
 
 declare i32 @arraylist_size_int(ptr)
 
-declare void @arraylist_add_string(ptr, ptr)
-
-declare void @arraylist_addAll_string(ptr, ptr, i64)
-
-declare void @arraylist_print_string(ptr)
-
-declare void @arraylist_add_String(ptr, ptr)
-
-declare void @arraylist_addAll_String(ptr, ptr, i64)
-
-declare ptr @getItem(ptr, i64)
-
-define void @print_Set(ptr %p) {
-entry:
-  ret void
-}
-
-define void @print_Set_boolean(ptr %p) {
-entry:
-  %v0 = load ptr, ptr %p, align 8
-  call void @arraylist_print_bool(ptr %v0)
-  ret void
-}
-
-define void @print_Set_string(ptr %p) {
-entry:
-  %v0 = load ptr, ptr %p, align 8
-  call void @arraylist_print_string(ptr %v0)
-  ret void
-}
-
-define void @print_Set_int(ptr %p) {
+define void @print_Row(ptr %p) {
 entry:
   %v0 = load ptr, ptr %p, align 8
   call void @arraylist_print_int(ptr %v0)
   ret void
 }
 
-define ptr @Set_boolean_add(ptr %s, i1 %value) {
+define void @print_Matrix(ptr %p) {
 entry:
-  %tmp72 = load ptr, ptr %s, align 8
-  %tmp83 = call i32 @arraylist_size_bool(ptr %tmp72)
-  %tmp94 = icmp slt i32 0, %tmp83
-  %tmp155 = load ptr, ptr %s, align 8
-  br i1 %tmp94, label %while_body_1.lr.ph, label %while_end_2
+  ret void
+}
+
+define ptr @Matrix_adRow(ptr %s, i32 %a, i32 %b, i32 %c) {
+entry:
+  %tmp2 = call ptr @malloc(i64 8)
+  %tmp4 = call ptr @arraylist_create_int(i64 10)
+  store ptr %tmp4, ptr %tmp2, align 8
+  call void @arraylist_add_int(ptr %tmp4, i32 %a)
+  %tmp20 = load ptr, ptr %tmp2, align 8
+  call void @arraylist_add_int(ptr %tmp20, i32 %b)
+  %tmp28 = load ptr, ptr %tmp2, align 8
+  call void @arraylist_add_int(ptr %tmp28, i32 %c)
+  %tmp32 = load ptr, ptr %s, align 8
+  call void @arraylist_add_ptr(ptr %tmp32, ptr %tmp2)
+  ret ptr %s
+
+0:                                                ; No predecessors!
+  ret ptr %s
+}
+
+define ptr @Matrix_printMatrix(ptr %s) {
+entry:
+  %tmp416 = load ptr, ptr %s, align 8
+  %tmp437 = call i32 @length(ptr %tmp416)
+  %tmp448 = icmp slt i32 0, %tmp437
+  br i1 %tmp448, label %while_body_1.lr.ph, label %while_end_2
 
 while_body_1.lr.ph:                               ; preds = %entry
   br label %while_body_1
 
-while_cond_0:                                     ; preds = %while_body_1
-  %i.0 = phi i32 [ %tmp25, %while_body_1 ]
-  %tmp7 = load ptr, ptr %s, align 8
-  %tmp8 = call i32 @arraylist_size_bool(ptr %tmp7)
-  %tmp9 = icmp slt i32 %i.0, %tmp8
-  %tmp15 = load ptr, ptr %s, align 8
-  br i1 %tmp9, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
+while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_end_5
+  %i.09 = phi i32 [ 0, %while_body_1.lr.ph ], [ %tmp79, %while_end_5 ]
+  %r_1 = alloca ptr, align 8
+  %tmp47 = load ptr, ptr %s, align 8
+  %tmp49 = zext i32 %i.09 to i64
+  %tmp50 = call ptr @arraylist_get_ptr(ptr %tmp47, i64 %tmp49)
+  store ptr %tmp50, ptr %r_1, align 8
+  %j = alloca i32, align 4
+  store i32 0, ptr %j, align 4
+  %tmp531 = load i32, ptr %j, align 4
+  %tmp572 = load ptr, ptr %r_1, align 8
+  %tmp593 = load ptr, ptr %tmp572, align 8
+  %tmp604 = call i32 @arraylist_size_int(ptr %tmp593)
+  %tmp615 = icmp slt i32 %tmp531, %tmp604
+  br i1 %tmp615, label %while_body_4.lr.ph, label %while_end_5
 
-while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_cond_0
-  %tmp157 = phi ptr [ %tmp155, %while_body_1.lr.ph ], [ %tmp15, %while_cond_0 ]
-  %i.06 = phi i32 [ 0, %while_body_1.lr.ph ], [ %i.0, %while_cond_0 ]
-  %tmp17 = zext i32 %i.06 to i64
-  %tmp18 = alloca i1, align 1
-  %tmp19 = call i1 @arraylist_get_bool(ptr %tmp157, i64 %tmp17, ptr %tmp18)
-  %tmp20 = load i1, ptr %tmp18, align 1
-  %tmp22 = icmp eq i1 %tmp20, %value
-  %tmp25 = add i32 %i.06, 1
-  br i1 %tmp22, label %then_0, label %while_cond_0
+while_body_4.lr.ph:                               ; preds = %while_body_1
+  br label %while_body_4
 
-then_0:                                           ; preds = %while_body_1
-  ret ptr %s
+while_body_4:                                     ; preds = %while_body_4.lr.ph, %while_body_4
+  %tmp65 = load ptr, ptr %r_1, align 8
+  %tmp67 = load ptr, ptr %tmp65, align 8
+  %tmp68 = load i32, ptr %j, align 4
+  %tmp69 = zext i32 %tmp68 to i64
+  %tmp70 = alloca i32, align 4
+  %tmp71 = call i32 @arraylist_get_int(ptr %tmp67, i64 %tmp69, ptr %tmp70)
+  %tmp72 = load i32, ptr %tmp70, align 4
+  %0 = call i32 (ptr, ...) @printf(ptr @.strInt, i32 %tmp72)
+  %tmp73 = load i32, ptr %j, align 4
+  %tmp75 = add i32 %tmp73, 1
+  store i32 %tmp75, ptr %j, align 4
+  %tmp53 = load i32, ptr %j, align 4
+  %tmp57 = load ptr, ptr %r_1, align 8
+  %tmp59 = load ptr, ptr %tmp57, align 8
+  %tmp60 = call i32 @arraylist_size_int(ptr %tmp59)
+  %tmp61 = icmp slt i32 %tmp53, %tmp60
+  br i1 %tmp61, label %while_body_4, label %while_cond_3.while_end_5_crit_edge
 
-0:                                                ; No predecessors!
-  unreachable
+while_cond_3.while_end_5_crit_edge:               ; preds = %while_body_4
+  br label %while_end_5
 
-while_cond_0.while_end_2_crit_edge:               ; preds = %while_cond_0
-  %split = phi ptr [ %tmp15, %while_cond_0 ]
+while_end_5:                                      ; preds = %while_cond_3.while_end_5_crit_edge, %while_body_1
+  %1 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str0)
+  %tmp79 = add i32 %i.09, 1
+  %tmp41 = load ptr, ptr %s, align 8
+  %tmp43 = call i32 @length(ptr %tmp41)
+  %tmp44 = icmp slt i32 %tmp79, %tmp43
+  br i1 %tmp44, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
+
+while_cond_0.while_end_2_crit_edge:               ; preds = %while_end_5
   br label %while_end_2
 
 while_end_2:                                      ; preds = %while_cond_0.while_end_2_crit_edge, %entry
-  %tmp15.lcssa = phi ptr [ %split, %while_cond_0.while_end_2_crit_edge ], [ %tmp155, %entry ]
-  call void @arraylist_add_bool(ptr %tmp15.lcssa, i1 %value)
   ret ptr %s
 
-1:                                                ; No predecessors!
-  ret ptr undef
+2:                                                ; No predecessors!
+  ret ptr %s
 }
 
-define ptr @Set_string_add(ptr %s, ptr %value) {
+define i32 @Matrix_somar(ptr %s, i32 %b, i32 %c) {
 entry:
-  %tmp42 = load ptr, ptr %s, align 8
-  %tmp63 = call i32 @length(ptr %tmp42)
-  %tmp74 = icmp slt i32 0, %tmp63
-  %tmp105 = load ptr, ptr %s, align 8
-  br i1 %tmp74, label %while_body_1.lr.ph, label %while_end_2
-
-while_body_1.lr.ph:                               ; preds = %entry
-  br label %while_body_1
-
-while_cond_0:                                     ; preds = %while_body_1
-  %i.0 = phi i32 [ %tmp21, %while_body_1 ]
-  %tmp4 = load ptr, ptr %s, align 8
-  %tmp6 = call i32 @length(ptr %tmp4)
-  %tmp7 = icmp slt i32 %i.0, %tmp6
-  %tmp10 = load ptr, ptr %s, align 8
-  br i1 %tmp7, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
-
-while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_cond_0
-  %tmp107 = phi ptr [ %tmp105, %while_body_1.lr.ph ], [ %tmp10, %while_cond_0 ]
-  %i.06 = phi i32 [ 0, %while_body_1.lr.ph ], [ %i.0, %while_cond_0 ]
-  %tmp12 = zext i32 %i.06 to i64
-  %tmp13 = call ptr @arraylist_get_ptr(ptr %tmp107, i64 %tmp12)
-  %tmp17 = call ptr @createString(ptr %tmp13)
-  %tmp18 = call i1 @strcmp_eq(ptr %tmp17, ptr %value)
-  %tmp21 = add i32 %i.06, 1
-  br i1 %tmp18, label %then_0, label %while_cond_0
-
-then_0:                                           ; preds = %while_body_1
-  ret ptr %s
+  %tmp83 = add i32 %c, %b
+  ret i32 %tmp83
 
 0:                                                ; No predecessors!
-  unreachable
-
-while_cond_0.while_end_2_crit_edge:               ; preds = %while_cond_0
-  %split = phi ptr [ %tmp10, %while_cond_0 ]
-  br label %while_end_2
-
-while_end_2:                                      ; preds = %while_cond_0.while_end_2_crit_edge, %entry
-  %tmp10.lcssa = phi ptr [ %split, %while_cond_0.while_end_2_crit_edge ], [ %tmp105, %entry ]
-  call void @arraylist_add_String(ptr %tmp10.lcssa, ptr %value)
-  ret ptr %s
-
-1:                                                ; No predecessors!
-  ret ptr undef
+  ret i32 undef
 }
 
-define ptr @Set_int_add(ptr %s, i32 %value) {
+define i32 @Matrix_sum(ptr %s) {
 entry:
-  %tmp72 = load ptr, ptr %s, align 8
-  %tmp83 = call i32 @arraylist_size_int(ptr %tmp72)
-  %tmp94 = icmp slt i32 0, %tmp83
-  %tmp155 = load ptr, ptr %s, align 8
-  br i1 %tmp94, label %while_body_1.lr.ph, label %while_end_2
+  %tmp88 = load ptr, ptr %s, align 8
+  %tmp91 = call ptr @arraylist_get_ptr(ptr %tmp88, i64 0)
+  %tmp967 = load ptr, ptr %s, align 8
+  %tmp988 = call i32 @length(ptr %tmp967)
+  %tmp999 = icmp slt i32 0, %tmp988
+  br i1 %tmp999, label %while_body_7.lr.ph, label %while_end_8
 
-while_body_1.lr.ph:                               ; preds = %entry
-  br label %while_body_1
+while_body_7.lr.ph:                               ; preds = %entry
+  br label %while_body_7
 
-while_cond_0:                                     ; preds = %while_body_1
-  %i.0 = phi i32 [ %tmp25, %while_body_1 ]
-  %tmp7 = load ptr, ptr %s, align 8
-  %tmp8 = call i32 @arraylist_size_int(ptr %tmp7)
-  %tmp9 = icmp slt i32 %i.0, %tmp8
-  %tmp15 = load ptr, ptr %s, align 8
-  br i1 %tmp9, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
+while_body_7:                                     ; preds = %while_body_7.lr.ph, %while_end_11
+  %i_1.011 = phi i32 [ 0, %while_body_7.lr.ph ], [ %tmp134, %while_end_11 ]
+  %total.010 = phi i32 [ 0, %while_body_7.lr.ph ], [ %total.1.lcssa, %while_end_11 ]
+  %r_3 = alloca ptr, align 8
+  %tmp102 = load ptr, ptr %s, align 8
+  %tmp104 = zext i32 %i_1.011 to i64
+  %tmp105 = call ptr @arraylist_get_ptr(ptr %tmp102, i64 %tmp104)
+  store ptr %tmp105, ptr %r_3, align 8
+  %j_1 = alloca i32, align 4
+  store i32 0, ptr %j_1, align 4
+  %tmp1081 = load i32, ptr %j_1, align 4
+  %tmp1122 = load ptr, ptr %r_3, align 8
+  %tmp1143 = load ptr, ptr %tmp1122, align 8
+  %tmp1154 = call i32 @arraylist_size_int(ptr %tmp1143)
+  %tmp1165 = icmp slt i32 %tmp1081, %tmp1154
+  br i1 %tmp1165, label %while_body_10.lr.ph, label %while_end_11
 
-while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_cond_0
-  %tmp157 = phi ptr [ %tmp155, %while_body_1.lr.ph ], [ %tmp15, %while_cond_0 ]
-  %i.06 = phi i32 [ 0, %while_body_1.lr.ph ], [ %i.0, %while_cond_0 ]
-  %tmp17 = zext i32 %i.06 to i64
-  %tmp18 = alloca i32, align 4
-  %tmp19 = call i32 @arraylist_get_int(ptr %tmp157, i64 %tmp17, ptr %tmp18)
-  %tmp20 = load i32, ptr %tmp18, align 4
-  %tmp22 = icmp eq i32 %tmp20, %value
-  %tmp25 = add i32 %i.06, 1
-  br i1 %tmp22, label %then_0, label %while_cond_0
+while_body_10.lr.ph:                              ; preds = %while_body_7
+  br label %while_body_10
 
-then_0:                                           ; preds = %while_body_1
-  ret ptr %s
+while_body_10:                                    ; preds = %while_body_10.lr.ph, %while_body_10
+  %total.16 = phi i32 [ %total.010, %while_body_10.lr.ph ], [ %tmp129, %while_body_10 ]
+  %tmp121 = load ptr, ptr %r_3, align 8
+  %tmp123 = load ptr, ptr %tmp121, align 8
+  %tmp124 = load i32, ptr %j_1, align 4
+  %tmp125 = zext i32 %tmp124 to i64
+  %tmp126 = alloca i32, align 4
+  %tmp127 = call i32 @arraylist_get_int(ptr %tmp123, i64 %tmp125, ptr %tmp126)
+  %tmp128 = load i32, ptr %tmp126, align 4
+  %tmp129 = add i32 %tmp128, %total.16
+  %tmp130 = load i32, ptr %j_1, align 4
+  %tmp132 = add i32 %tmp130, 1
+  store i32 %tmp132, ptr %j_1, align 4
+  %tmp108 = load i32, ptr %j_1, align 4
+  %tmp112 = load ptr, ptr %r_3, align 8
+  %tmp114 = load ptr, ptr %tmp112, align 8
+  %tmp115 = call i32 @arraylist_size_int(ptr %tmp114)
+  %tmp116 = icmp slt i32 %tmp108, %tmp115
+  br i1 %tmp116, label %while_body_10, label %while_cond_9.while_end_11_crit_edge
+
+while_cond_9.while_end_11_crit_edge:              ; preds = %while_body_10
+  %split = phi i32 [ %tmp129, %while_body_10 ]
+  br label %while_end_11
+
+while_end_11:                                     ; preds = %while_cond_9.while_end_11_crit_edge, %while_body_7
+  %total.1.lcssa = phi i32 [ %split, %while_cond_9.while_end_11_crit_edge ], [ %total.010, %while_body_7 ]
+  %tmp134 = add i32 %i_1.011, 1
+  %tmp96 = load ptr, ptr %s, align 8
+  %tmp98 = call i32 @length(ptr %tmp96)
+  %tmp99 = icmp slt i32 %tmp134, %tmp98
+  br i1 %tmp99, label %while_body_7, label %while_cond_6.while_end_8_crit_edge
+
+while_cond_6.while_end_8_crit_edge:               ; preds = %while_end_11
+  %split12 = phi i32 [ %total.1.lcssa, %while_end_11 ]
+  br label %while_end_8
+
+while_end_8:                                      ; preds = %while_cond_6.while_end_8_crit_edge, %entry
+  %total.0.lcssa = phi i32 [ %split12, %while_cond_6.while_end_8_crit_edge ], [ 0, %entry ]
+  ret i32 %total.0.lcssa
 
 0:                                                ; No predecessors!
-  unreachable
-
-while_cond_0.while_end_2_crit_edge:               ; preds = %while_cond_0
-  %split = phi ptr [ %tmp15, %while_cond_0 ]
-  br label %while_end_2
-
-while_end_2:                                      ; preds = %while_cond_0.while_end_2_crit_edge, %entry
-  %tmp15.lcssa = phi ptr [ %split, %while_cond_0.while_end_2_crit_edge ], [ %tmp155, %entry ]
-  call void @arraylist_add_int(ptr %tmp15.lcssa, i32 %value)
-  ret ptr %s
-
-1:                                                ; No predecessors!
-  ret ptr undef
-}
-
-define ptr @Set_boolean_remove(ptr %s, i32 %index) {
-entry:
-  %tmp5 = load ptr, ptr %s, align 8
-  %tmp7 = zext i32 %index to i64
-  call void @arraylist_remove_bool(ptr %tmp5, i64 %tmp7)
-  ret ptr %s
-
-0:                                                ; No predecessors!
-  ret ptr undef
-}
-
-define ptr @Set_string_remove(ptr %s, i32 %index) {
-entry:
-  %tmp2 = load ptr, ptr %s, align 8
-  %tmp4 = zext i32 %index to i64
-  call void @removeItem(ptr %tmp2, i64 %tmp4)
-  ret ptr %s
-
-0:                                                ; No predecessors!
-  ret ptr undef
-}
-
-define ptr @Set_int_remove(ptr %s, i32 %index) {
-entry:
-  %tmp5 = load ptr, ptr %s, align 8
-  %tmp7 = zext i32 %index to i64
-  call void @arraylist_remove_int(ptr %tmp5, i64 %tmp7)
-  ret ptr %s
-
-0:                                                ; No predecessors!
-  ret ptr undef
+  ret i32 undef
 }
 
 define i32 @main() {
-  %tmp0 = alloca %Set_int, align 8
-  %tmp1 = call ptr @arraylist_create_int(i64 10)
-  store ptr %tmp1, ptr %tmp0, align 8
-  call void @Set_int_add(ptr %tmp0, i32 3)
-  call void @Set_int_add(ptr %tmp0, i32 3)
-  call void @print_Set_int(ptr %tmp0)
-  %tmp8 = alloca %Set_boolean, align 8
-  %tmp9 = call ptr @arraylist_create_bool(i64 10)
-  store ptr %tmp9, ptr %tmp8, align 8
-  call void @Set_boolean_add(ptr %tmp8, i1 true)
-  call void @Set_boolean_add(ptr %tmp8, i1 false)
-  call void @Set_boolean_add(ptr %tmp8, i1 true)
-  call void @print_Set_boolean(ptr %tmp8)
-  %tmp18 = alloca %Set_string, align 8
-  %tmp19 = call ptr @arraylist_create(i64 10)
-  store ptr %tmp19, ptr %tmp18, align 8
-  %tmp23 = call ptr @createString(ptr @.str0)
-  call void @Set_string_add(ptr %tmp18, ptr %tmp23)
-  %tmp26 = call ptr @createString(ptr @.str0)
-  call void @Set_string_add(ptr %tmp18, ptr %tmp26)
-  call void @print_Set_string(ptr %tmp18)
-  %1 = call i32 @getchar()
+  %tmp138 = call ptr @malloc(i64 8)
+  %tmp140 = call ptr @arraylist_create(i64 10)
+  store ptr %tmp140, ptr %tmp138, align 8
+  call void @Matrix_adRow(ptr %tmp138, i32 1, i32 2, i32 3)
+  call void @Matrix_adRow(ptr %tmp138, i32 4, i32 5, i32 6)
+  call void @Matrix_adRow(ptr %tmp138, i32 7, i32 8, i32 9)
+  %1 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str1)
+  call void @Matrix_printMatrix(ptr %tmp138)
+  %2 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str2)
+  %tmp158 = call i32 @Matrix_sum(ptr %tmp138)
+  %3 = call i32 (ptr, ...) @printf(ptr @.strInt, i32 %tmp158)
+  %4 = call i32 @getchar()
   ret i32 0
 }

--- a/src/language/main.zd
+++ b/src/language/main.zd
@@ -1,19 +1,75 @@
-import "src/language/structs/impls/monomorfizacao.zd";
 
 main {
-    Set<int> numeros;
-    numeros.add(3);
-    numeros.add(3);
-    print(numeros);
+Struct Row {
+    List<int> values;
+}
 
-    Set<boolean> real;
-    real.add(true);
-    real.add(false);
-    real.add(true);
-    print(real);
+Struct Matrix {
+    List<Row> rows;
+}
 
-    Set<string> names;
-    names.add("zard");
-    names.add("zard");
-    print(names);
+
+impl Matrix {
+
+    function adRow(int a, int b, int c) {
+        Row r;
+        r.values.add(a);
+        r.values.add(b);
+        r.values.add(c);
+        s.rows.add(r);
+        return s;
+    }
+
+    function printMatrix() {
+        int i = 0;
+
+        while (i < s.rows.size()) {
+            Row r = s.rows.get(i);
+            int j = 0;
+
+            while (j < r.values.size()) {
+                print(r.values.get(j));
+                j = j + 1;
+            }
+
+            print("---");
+            i = i + 1;
+        }
+        return s;
+    }
+    function int somar(int b, int c) {
+        return b +c;
+    }
+    function int sum() {
+        int total = 0;
+        int i = 0;
+        Row r = s.rows.get(i);
+        while (i < s.rows.size()) {
+            Row r = s.rows.get(i);
+            int j = 0;
+
+            while (j < r.values.size()) {
+                total = total + r.values.get(j);
+                j = j + 1;
+            }
+
+            i++;
+        }
+        return total;
+    }
+}
+
+
+    Matrix mat;
+
+    mat.adRow(1, 2, 3);
+    mat.adRow(4, 5, 6);
+    mat.adRow(7, 8, 9);
+
+
+    print("Matriz:");
+    mat.printMatrix();
+
+    print("Soma total:");
+    print(mat.sum());
 }

--- a/src/low/structs/StructInstanceEmitter.java
+++ b/src/low/structs/StructInstanceEmitter.java
@@ -11,14 +11,11 @@ import low.module.LLVisitorMain;
 
 import java.util.List;
 import java.util.Map;
-
 public class StructInstanceEmitter {
     private final TempManager tempManager;
-    private final GlobalStringManager stringManager;
 
     public StructInstanceEmitter(TempManager tempManager, GlobalStringManager stringManager) {
         this.tempManager = tempManager;
-        this.stringManager = stringManager;
     }
 
     public String emit(StructInstaceNode node, LLVisitorMain visitor) {
@@ -26,32 +23,33 @@ public class StructInstanceEmitter {
         StringBuilder llvm = new StringBuilder();
 
         String baseStructName = node.getName();
-        String concreteType = node.getConcreteType();
+        String concreteType  = node.getConcreteType();
 
         TypeMapper mapper = new TypeMapper();
-        String structLLVMType =
+
+        String structLLVMPtrType =
                 (concreteType != null && !concreteType.isEmpty())
                         ? mapper.toLLVM(concreteType)
                         : mapper.toLLVM("Struct<" + baseStructName + ">");
 
-        // remover * extra
-        if (structLLVMType.endsWith("*")) {
-            structLLVMType = structLLVMType.substring(0, structLLVMType.length() - 1);
+        if (!structLLVMPtrType.endsWith("*")) {
+            structLLVMPtrType = structLLVMPtrType + "*";
         }
 
-        // ==== RESOLVER elemType ====
+        String structLLVMType = structLLVMPtrType.substring(0, structLLVMPtrType.length() - 1);
+
         String elemType = null;
 
         if (concreteType != null && concreteType.startsWith("Struct<")) {
-            int lt1 = concreteType.indexOf('<');
-            int lt2 = concreteType.indexOf('<', lt1 + 1);
-            int gt = concreteType.indexOf('>', lt2 + 1);
-            if (lt2 != -1 && gt != -1 && lt2 + 1 < gt) {
-                elemType = concreteType.substring(lt2 + 1, gt).trim();
+            int firstLt  = concreteType.indexOf('<');
+            int secondLt = concreteType.indexOf('<', firstLt + 1);
+            int gt       = concreteType.lastIndexOf('>');
+
+            if (secondLt != -1 && gt != -1 && secondLt + 1 < gt) {
+                elemType = concreteType.substring(secondLt + 1, gt).trim();
             }
         }
 
-        // fallback
         if (elemType == null) {
             String shortName = structLLVMType.startsWith("%")
                     ? structLLVMType.substring(1)
@@ -63,10 +61,10 @@ public class StructInstanceEmitter {
             }
         }
 
-        // ==== RESOLVER STRUCTNODE ====
         StructNode def;
         if (elemType != null) {
             StructNode base = visitor.getStructNode(baseStructName);
+            if (base == null) throw new RuntimeException("Struct base não encontrada: " + baseStructName);
             def = visitor.getOrCreateSpecializedStruct(base, elemType);
         } else {
             def = visitor.getStructNode(baseStructName);
@@ -76,152 +74,79 @@ public class StructInstanceEmitter {
             throw new RuntimeException("Struct não encontrada: " + baseStructName);
         }
 
-        // ==== CALCULAR TAMANHO ====
-        int structSize = def.getLLVMSizeBytes();
+        String gepTmp  = tempManager.newTemp();
+        String sizeTmp = tempManager.newTemp();
+        String rawPtr  = tempManager.newTemp();
+        String objPtr  = tempManager.newTemp();
 
-        // ==== malloc ====
-        String mallocTmp = tempManager.newTemp();
-        llvm.append("  ").append(mallocTmp)
-                .append(" = call i8* @malloc(i64 ").append(structSize).append(")\n");
+        llvm.append("  ").append(gepTmp)
+                .append(" = getelementptr ").append(structLLVMType)
+                .append(", ").append(structLLVMType).append("* null, i32 1\n");
 
-        String structPtr = tempManager.newTemp();
-        llvm.append("  ").append(structPtr)
-                .append(" = bitcast i8* ").append(mallocTmp)
+        llvm.append("  ").append(sizeTmp)
+                .append(" = ptrtoint ").append(structLLVMType)
+                .append("* ").append(gepTmp).append(" to i64\n");
+
+        llvm.append("  ").append(rawPtr)
+                .append(" = call i8* @malloc(i64 ").append(sizeTmp).append(")\n");
+
+        llvm.append("  ").append(objPtr)
+                .append(" = bitcast i8* ").append(rawPtr)
                 .append(" to ").append(structLLVMType).append("*\n");
 
-        // ==== inicializar campos ====
-
-        List<VariableDeclarationNode> fields = def.getFields();
-        List<ASTNode> posValues = node.getPositionalValues();
-        Map<String, ASTNode> namedValues = node.getNamedValues();
-
-        int providedPos = (posValues == null ? 0 : posValues.size());
+        var fields = def.getFields();
 
         for (int i = 0; i < fields.size(); i++) {
-
             VariableDeclarationNode field = fields.get(i);
-            String fname = field.getName();
             String fieldType = field.getType();
 
-            String effectiveFieldType = fieldType;
-            if (elemType != null && fieldType.startsWith("List<") && fieldType.contains("?")) {
-                effectiveFieldType = "List<" + elemType + ">";
+            if (!fieldType.startsWith("List<")) continue;
+
+            String elem = fieldType.substring(5, fieldType.length() - 1).trim();
+
+            String listLLVMType;
+            String listCreateFn;
+
+            switch (elem) {
+                case "int" -> {
+                    listLLVMType = "%struct.ArrayListInt*";
+                    listCreateFn = "@arraylist_create_int";
+                }
+                case "double" -> {
+                    listLLVMType = "%struct.ArrayListDouble*";
+                    listCreateFn = "@arraylist_create_double";
+                }
+                case "boolean" -> {
+                    listLLVMType = "%struct.ArrayListBool*";
+                    listCreateFn = "@arraylist_create_bool";
+                }
+                default -> {
+                    listLLVMType = "%ArrayList*";
+                    listCreateFn = "@arraylist_create";
+                }
             }
 
-            ASTNode providedValue = null;
-
-            if (namedValues.containsKey(fname)) {
-                providedValue = namedValues.get(fname);
-            } else if (i < providedPos) {
-                providedValue = posValues.get(i);
-            }
-
-            String fieldLLVMType = mapFieldTypeForStruct(effectiveFieldType);
-
-            String valueTemp;
-            String before = "";
-
-            if (providedValue != null) {
-                before = providedValue.accept(visitor);
-                valueTemp = extractTemp(before);
-            } else {
-                valueTemp = emitDefaultValue(effectiveFieldType, fieldLLVMType, llvm);
-            }
-
-            llvm.append(before);
-
+            String listTmp  = tempManager.newTemp();
             String fieldPtr = tempManager.newTemp();
+
+            llvm.append("  ").append(listTmp)
+                    .append(" = call ").append(listLLVMType)
+                    .append(" ").append(listCreateFn)
+                    .append("(i64 10)\n");
+
             llvm.append("  ").append(fieldPtr)
                     .append(" = getelementptr inbounds ")
                     .append(structLLVMType).append(", ").append(structLLVMType)
-                    .append("* ").append(structPtr).append(", i32 0, i32 ").append(i).append("\n");
+                    .append("* ").append(objPtr)
+                    .append(", i32 0, i32 ").append(i).append("\n");
 
-            llvm.append("  store ").append(fieldLLVMType).append(" ").append(valueTemp)
-                    .append(", ").append(fieldLLVMType).append("* ").append(fieldPtr).append("\n");
+            llvm.append("  store ").append(listLLVMType).append(" ").append(listTmp)
+                    .append(", ").append(listLLVMType).append("* ").append(fieldPtr).append("\n");
         }
 
-        llvm.append(";;VAL:").append(structPtr).append(";;TYPE:").append(structLLVMType).append("*\n");
+        llvm.append(";;VAL:").append(objPtr)
+                .append(";;TYPE:").append(structLLVMPtrType).append("\n");
+
         return llvm.toString();
-    }
-
-
-    private String mapFieldTypeForStruct(String type) {
-        if (type.startsWith("List<")) {
-            String inner = type.substring(5, type.length() - 1).trim();
-            return switch (inner) {
-                case "int" -> "%struct.ArrayListInt*";
-                case "double" -> "%struct.ArrayListDouble*";
-                case "boolean" -> "%struct.ArrayListBool*";
-                case "string" -> "%ArrayList*";
-                default -> "%ArrayList*";
-            };
-        }
-        if (type.startsWith("Struct ")) {
-            String inner = type.substring("Struct ".length()).trim();
-            return "%" + inner + "*";
-        }
-        if (type.startsWith("Struct<") && type.endsWith(">")) {
-            String inner = type.substring(7, type.length() - 1).trim();
-            return "%" + inner + "*";
-        }
-        return new TypeMapper().toLLVM(type);
-    }
-
-    private String emitDefaultValue(String type, String fieldLLVMType, StringBuilder llvm) {
-        switch (type) {
-            case "int": return "0";
-            case "double":
-            case "float": return "0.0";
-            case "boolean": return "0";
-            case "string": {
-                String emptyLabel = stringManager.getGlobalName("");
-                String tmp = tempManager.newTemp();
-                llvm.append("  ").append(tmp)
-                        .append(" = call %String* @createString(i8* ").append(emptyLabel).append(")\n");
-                return tmp;
-            }
-            default:
-                if (type.startsWith("List<")) {
-                    String inner = type.substring(5, type.length() - 1).trim();
-                    String tmp = tempManager.newTemp();
-                    switch (inner) {
-                        case "int" -> {
-                            llvm.append("  ").append(tmp)
-                                    .append(" = call %struct.ArrayListInt* @arraylist_create_int(i64 10)\n");
-                            return tmp;
-                        }
-                        case "double" -> {
-                            llvm.append("  ").append(tmp)
-                                    .append(" = call %struct.ArrayListDouble* @arraylist_create_double(i64 10)\n");
-                            return tmp;
-                        }
-                        case "boolean" -> {
-                            llvm.append("  ").append(tmp)
-                                    .append(" = call %struct.ArrayListBool* @arraylist_create_bool(i64 10)\n");
-                            return tmp;
-                        }
-                        default -> {
-                            llvm.append("  ").append(tmp)
-                                    .append(" = call i8* @arraylist_create(i64 10)\n");
-                            String casted = tempManager.newTemp();
-                            llvm.append("  ").append(casted)
-                                    .append(" = bitcast i8* ").append(tmp).append(" to %ArrayList*\n");
-                            return casted;
-                        }
-                    }
-                } else if (type.startsWith("Struct")) {
-                    return "null";
-                }
-        }
-        return "zeroinitializer";
-    }
-
-    private String extractTemp(String code) {
-        int lastValIdx = code.lastIndexOf(";;VAL:");
-        if (lastValIdx == -1) {
-            throw new RuntimeException("Cannot find ;;VAL: in: " + code);
-        }
-        int typeIdx = code.indexOf(";;TYPE:", lastValIdx);
-        return code.substring(lastValIdx + 6, typeIdx).trim();
     }
 }


### PR DESCRIPTION
- Moved the responsibility for allocating memory and performing malloc from the  to the .
- Now, the  only handles the struct instance creation and field initialization without managing memory allocation.
-  handles all memory-related operations like  and pointer casting, ensuring that structs and their internal lists are initialized correctly.
- Fixed issue with undefined  value due to missing allocation in .
- Updated  to properly delegate to  for memory allocation when struct initialization is required.

This refactor simplifies the struct initialization flow and resolves the issue of uninitialized struct fields during the creation of struct instances.