### PR TITLE
fix(llvm): preserve correct LLVM types when printing expressions

### DIFF
--- a/programa_opt.ll
+++ b/programa_opt.ll
@@ -13,8 +13,325 @@ source_filename = "programa.ll"
 @.strStr = private constant [4 x i8] c"%s\0A\00"
 @.strStr_noNL = private constant [3 x i8] c"%s\00"
 @.strEmpty = private constant [1 x i8] zeroinitializer
-@.str0 = private constant [2 x i8] c" \00"
-@.str1 = private constant [1 x i8] zeroinitializer
+@.str0 = private constant [24 x i8] c"Erro: divisao por zero!\00"
+@.str1 = private constant [53 x i8] c"Aviso: expoente negativo nao suportado, retornando 0\00"
+@.str2 = private constant [31 x i8] c"Erro: sqrt de numero negativo!\00"
+@.str3 = private constant [36 x i8] c"Erro: factorial de numero negativo!\00"
+@.str4 = private constant [27 x i8] c"Tentando dividir por zero:\00"
+@.str5 = private constant [39 x i8] c"Tentando fatorial de n\C3\BAmero negativo:\00"
+@.str6 = private constant [44 x i8] c"Tentando raiz quadrada de n\C3\BAmero negativo:\00"
+@.str7 = private constant [16 x i8] c"Fim dos testes.\00"
+
+define double @sum(double %a, double %b) {
+entry:
+  %tmp2 = fadd double %a, %b
+  ret double %tmp2
+}
+
+define double @sub(double %a, double %b) {
+entry:
+  %tmp5 = fsub double %a, %b
+  ret double %tmp5
+}
+
+define double @mul(double %a, double %b) {
+entry:
+  %tmp8 = fmul double %a, %b
+  ret double %tmp8
+}
+
+define double @div(double %a, double %b) {
+entry:
+  %tmp11 = fcmp oeq double %b, 0.000000e+00
+  br i1 %tmp11, label %then_0, label %endif_0
+
+then_0:                                           ; preds = %entry
+  %0 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str0)
+  ret double 0.000000e+00
+
+1:                                                ; No predecessors!
+  br label %endif_0
+
+endif_0:                                          ; preds = %1, %entry
+  %tmp17 = fdiv double %a, %b
+  ret double %tmp17
+}
+
+define double @pow(double %base, i32 %exp) {
+entry:
+  %tmp20 = icmp slt i32 %exp, 0
+  br i1 %tmp20, label %then_1, label %endif_1
+
+then_1:                                           ; preds = %entry
+  %0 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str1)
+  ret double 0.000000e+00
+
+1:                                                ; No predecessors!
+  br label %endif_1
+
+endif_1:                                          ; preds = %1, %entry
+  %result = alloca double, align 8
+  store double 1.000000e+00, ptr %result, align 8
+  %i = alloca i32, align 4
+  store i32 0, ptr %i, align 4
+  %tmp251 = load i32, ptr %i, align 4
+  %tmp272 = icmp slt i32 %tmp251, %exp
+  %tmp333 = load double, ptr %result, align 8
+  br i1 %tmp272, label %while_body_1.lr.ph, label %while_end_2
+
+while_body_1.lr.ph:                               ; preds = %endif_1
+  br label %while_body_1
+
+while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_body_1
+  %tmp334 = phi double [ %tmp333, %while_body_1.lr.ph ], [ %tmp33, %while_body_1 ]
+  %tmp30 = fmul double %base, %tmp334
+  store double %tmp30, ptr %result, align 8
+  %tmp31 = load i32, ptr %i, align 4
+  %tmp32 = add i32 %tmp31, 1
+  store i32 %tmp32, ptr %i, align 4
+  %tmp25 = load i32, ptr %i, align 4
+  %tmp27 = icmp slt i32 %tmp25, %exp
+  %tmp33 = load double, ptr %result, align 8
+  br i1 %tmp27, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
+
+while_cond_0.while_end_2_crit_edge:               ; preds = %while_body_1
+  %split = phi double [ %tmp33, %while_body_1 ]
+  br label %while_end_2
+
+while_end_2:                                      ; preds = %while_cond_0.while_end_2_crit_edge, %endif_1
+  %tmp33.lcssa = phi double [ %split, %while_cond_0.while_end_2_crit_edge ], [ %tmp333, %endif_1 ]
+  ret double %tmp33.lcssa
+}
+
+define double @sqrt(double %x) {
+entry:
+  %tmp36 = fcmp olt double %x, 0.000000e+00
+  br i1 %tmp36, label %then_2, label %endif_2
+
+then_2:                                           ; preds = %entry
+  %0 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str2)
+  ret double 0.000000e+00
+
+1:                                                ; No predecessors!
+  br label %endif_2
+
+endif_2:                                          ; preds = %1, %entry
+  %guess = alloca double, align 8
+  %tmp42 = fdiv double %x, 2.000000e+00
+  store double %tmp42, ptr %guess, align 8
+  %i_1 = alloca i32, align 4
+  store i32 0, ptr %i_1, align 4
+  %tmp441 = load i32, ptr %i_1, align 4
+  %tmp462 = icmp slt i32 %tmp441, 20
+  %tmp563 = load double, ptr %guess, align 8
+  br i1 %tmp462, label %while_body_4.lr.ph, label %while_end_5
+
+while_body_4.lr.ph:                               ; preds = %endif_2
+  br label %while_body_4
+
+while_body_4:                                     ; preds = %while_body_4.lr.ph, %while_body_4
+  %tmp564 = phi double [ %tmp563, %while_body_4.lr.ph ], [ %tmp56, %while_body_4 ]
+  %tmp50 = fdiv double %x, %tmp564
+  %tmp51 = fadd double %tmp564, %tmp50
+  %tmp53 = fdiv double %tmp51, 2.000000e+00
+  store double %tmp53, ptr %guess, align 8
+  %tmp54 = load i32, ptr %i_1, align 4
+  %tmp55 = add i32 %tmp54, 1
+  store i32 %tmp55, ptr %i_1, align 4
+  %tmp44 = load i32, ptr %i_1, align 4
+  %tmp46 = icmp slt i32 %tmp44, 20
+  %tmp56 = load double, ptr %guess, align 8
+  br i1 %tmp46, label %while_body_4, label %while_cond_3.while_end_5_crit_edge
+
+while_cond_3.while_end_5_crit_edge:               ; preds = %while_body_4
+  %split = phi double [ %tmp56, %while_body_4 ]
+  br label %while_end_5
+
+while_end_5:                                      ; preds = %while_cond_3.while_end_5_crit_edge, %endif_2
+  %tmp56.lcssa = phi double [ %split, %while_cond_3.while_end_5_crit_edge ], [ %tmp563, %endif_2 ]
+  ret double %tmp56.lcssa
+}
+
+define double @sin(double %x) {
+entry:
+  br label %while_body_7
+
+while_body_7:                                     ; preds = %entry
+  %tmp64 = fsub double 0.000000e+00, %x
+  %tmp66 = fmul double %x, %tmp64
+  %tmp68 = fmul double %x, %tmp66
+  %tmp78 = fdiv double %tmp68, 6.000000e+00
+  %tmp82 = fadd double %x, %tmp78
+  %tmp64.1 = fsub double 0.000000e+00, %tmp78
+  %tmp66.1 = fmul double %x, %tmp64.1
+  %tmp68.1 = fmul double %x, %tmp66.1
+  %tmp78.1 = fdiv double %tmp68.1, 2.000000e+01
+  %tmp82.1 = fadd double %tmp82, %tmp78.1
+  %tmp64.2 = fsub double 0.000000e+00, %tmp78.1
+  %tmp66.2 = fmul double %x, %tmp64.2
+  %tmp68.2 = fmul double %x, %tmp66.2
+  %tmp78.2 = fdiv double %tmp68.2, 4.200000e+01
+  %tmp82.2 = fadd double %tmp82.1, %tmp78.2
+  %tmp64.3 = fsub double 0.000000e+00, %tmp78.2
+  %tmp66.3 = fmul double %x, %tmp64.3
+  %tmp68.3 = fmul double %x, %tmp66.3
+  %tmp78.3 = fdiv double %tmp68.3, 7.200000e+01
+  %tmp82.3 = fadd double %tmp82.2, %tmp78.3
+  %tmp64.4 = fsub double 0.000000e+00, %tmp78.3
+  %tmp66.4 = fmul double %x, %tmp64.4
+  %tmp68.4 = fmul double %x, %tmp66.4
+  %tmp78.4 = fdiv double %tmp68.4, 1.100000e+02
+  %tmp82.4 = fadd double %tmp82.3, %tmp78.4
+  %tmp64.5 = fsub double 0.000000e+00, %tmp78.4
+  %tmp66.5 = fmul double %x, %tmp64.5
+  %tmp68.5 = fmul double %x, %tmp66.5
+  %tmp78.5 = fdiv double %tmp68.5, 1.560000e+02
+  %tmp82.5 = fadd double %tmp82.4, %tmp78.5
+  %tmp64.6 = fsub double 0.000000e+00, %tmp78.5
+  %tmp66.6 = fmul double %x, %tmp64.6
+  %tmp68.6 = fmul double %x, %tmp66.6
+  %tmp78.6 = fdiv double %tmp68.6, 2.100000e+02
+  %tmp82.6 = fadd double %tmp82.5, %tmp78.6
+  %tmp64.7 = fsub double 0.000000e+00, %tmp78.6
+  %tmp66.7 = fmul double %x, %tmp64.7
+  %tmp68.7 = fmul double %x, %tmp66.7
+  %tmp78.7 = fdiv double %tmp68.7, 2.720000e+02
+  %tmp82.7 = fadd double %tmp82.6, %tmp78.7
+  %tmp64.8 = fsub double 0.000000e+00, %tmp78.7
+  %tmp66.8 = fmul double %x, %tmp64.8
+  %tmp68.8 = fmul double %x, %tmp66.8
+  %tmp78.8 = fdiv double %tmp68.8, 3.420000e+02
+  %tmp82.8 = fadd double %tmp82.7, %tmp78.8
+  ret double %tmp82.8
+}
+
+define double @cos(double %x) {
+entry:
+  br label %while_body_10
+
+while_body_10:                                    ; preds = %entry
+  %tmp95 = fmul double %x, -1.000000e+00
+  %tmp97 = fmul double %x, %tmp95
+  %tmp107 = fdiv double %tmp97, 2.000000e+00
+  %tmp111 = fadd double 1.000000e+00, %tmp107
+  %tmp93.1 = fsub double 0.000000e+00, %tmp107
+  %tmp95.1 = fmul double %x, %tmp93.1
+  %tmp97.1 = fmul double %x, %tmp95.1
+  %tmp107.1 = fdiv double %tmp97.1, 1.200000e+01
+  %tmp111.1 = fadd double %tmp111, %tmp107.1
+  %tmp93.2 = fsub double 0.000000e+00, %tmp107.1
+  %tmp95.2 = fmul double %x, %tmp93.2
+  %tmp97.2 = fmul double %x, %tmp95.2
+  %tmp107.2 = fdiv double %tmp97.2, 3.000000e+01
+  %tmp111.2 = fadd double %tmp111.1, %tmp107.2
+  %tmp93.3 = fsub double 0.000000e+00, %tmp107.2
+  %tmp95.3 = fmul double %x, %tmp93.3
+  %tmp97.3 = fmul double %x, %tmp95.3
+  %tmp107.3 = fdiv double %tmp97.3, 5.600000e+01
+  %tmp111.3 = fadd double %tmp111.2, %tmp107.3
+  %tmp93.4 = fsub double 0.000000e+00, %tmp107.3
+  %tmp95.4 = fmul double %x, %tmp93.4
+  %tmp97.4 = fmul double %x, %tmp95.4
+  %tmp107.4 = fdiv double %tmp97.4, 9.000000e+01
+  %tmp111.4 = fadd double %tmp111.3, %tmp107.4
+  %tmp93.5 = fsub double 0.000000e+00, %tmp107.4
+  %tmp95.5 = fmul double %x, %tmp93.5
+  %tmp97.5 = fmul double %x, %tmp95.5
+  %tmp107.5 = fdiv double %tmp97.5, 1.320000e+02
+  %tmp111.5 = fadd double %tmp111.4, %tmp107.5
+  %tmp93.6 = fsub double 0.000000e+00, %tmp107.5
+  %tmp95.6 = fmul double %x, %tmp93.6
+  %tmp97.6 = fmul double %x, %tmp95.6
+  %tmp107.6 = fdiv double %tmp97.6, 1.820000e+02
+  %tmp111.6 = fadd double %tmp111.5, %tmp107.6
+  %tmp93.7 = fsub double 0.000000e+00, %tmp107.6
+  %tmp95.7 = fmul double %x, %tmp93.7
+  %tmp97.7 = fmul double %x, %tmp95.7
+  %tmp107.7 = fdiv double %tmp97.7, 2.400000e+02
+  %tmp111.7 = fadd double %tmp111.6, %tmp107.7
+  %tmp93.8 = fsub double 0.000000e+00, %tmp107.7
+  %tmp95.8 = fmul double %x, %tmp93.8
+  %tmp97.8 = fmul double %x, %tmp95.8
+  %tmp107.8 = fdiv double %tmp97.8, 3.060000e+02
+  %tmp111.8 = fadd double %tmp111.7, %tmp107.8
+  ret double %tmp111.8
+}
+
+define i32 @fact(i32 %n) {
+entry:
+  %tmp117 = icmp slt i32 %n, 0
+  br i1 %tmp117, label %then_3, label %endif_3
+
+then_3:                                           ; preds = %entry
+  %0 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str3)
+  ret i32 0
+
+1:                                                ; No predecessors!
+  br label %endif_3
+
+endif_3:                                          ; preds = %1, %entry
+  %result_1 = alloca i32, align 4
+  store i32 1, ptr %result_1, align 4
+  %i_2 = alloca i32, align 4
+  store i32 1, ptr %i_2, align 4
+  %tmp1221 = load i32, ptr %i_2, align 4
+  %tmp1242 = icmp sle i32 %tmp1221, %n
+  %tmp1303 = load i32, ptr %result_1, align 4
+  br i1 %tmp1242, label %while_body_13.lr.ph, label %while_end_14
+
+while_body_13.lr.ph:                              ; preds = %endif_3
+  br label %while_body_13
+
+while_body_13:                                    ; preds = %while_body_13.lr.ph, %while_body_13
+  %tmp1305 = phi i32 [ %tmp1303, %while_body_13.lr.ph ], [ %tmp130, %while_body_13 ]
+  %tmp1224 = phi i32 [ %tmp1221, %while_body_13.lr.ph ], [ %tmp122, %while_body_13 ]
+  %tmp127 = mul i32 %tmp1305, %tmp1224
+  store i32 %tmp127, ptr %result_1, align 4
+  %tmp128 = load i32, ptr %i_2, align 4
+  %tmp129 = add i32 %tmp128, 1
+  store i32 %tmp129, ptr %i_2, align 4
+  %tmp122 = load i32, ptr %i_2, align 4
+  %tmp124 = icmp sle i32 %tmp122, %n
+  %tmp130 = load i32, ptr %result_1, align 4
+  br i1 %tmp124, label %while_body_13, label %while_cond_12.while_end_14_crit_edge
+
+while_cond_12.while_end_14_crit_edge:             ; preds = %while_body_13
+  %split = phi i32 [ %tmp130, %while_body_13 ]
+  br label %while_end_14
+
+while_end_14:                                     ; preds = %while_cond_12.while_end_14_crit_edge, %endif_3
+  %tmp130.lcssa = phi i32 [ %split, %while_cond_12.while_end_14_crit_edge ], [ %tmp1303, %endif_3 ]
+  ret i32 %tmp130.lcssa
+}
+
+define i32 @factorial(i32 %n) {
+entry:
+  %tmp133 = icmp slt i32 %n, 0
+  br i1 %tmp133, label %then_4, label %endif_4
+
+then_4:                                           ; preds = %entry
+  %0 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str3)
+  ret i32 0
+
+1:                                                ; No predecessors!
+  br label %endif_4
+
+endif_4:                                          ; preds = %1, %entry
+  %tmp138 = icmp eq i32 %n, 0
+  br i1 %tmp138, label %then_5, label %endif_5
+
+then_5:                                           ; preds = %endif_4
+  ret i32 1
+
+2:                                                ; No predecessors!
+  br label %endif_5
+
+endif_5:                                          ; preds = %2, %endif_4
+  %tmp143 = sub i32 %n, 1
+  %tmp144 = call i32 @factorial(i32 %tmp143)
+  %tmp145 = mul i32 %tmp144, %n
+  ret i32 %tmp145
+}
 
 declare i32 @printf(ptr, ...)
 
@@ -34,161 +351,35 @@ declare i1 @strcmp_eq(ptr, ptr)
 
 declare i1 @strcmp_neq(ptr, ptr)
 
-declare ptr @arraylist_create(i64)
-
-declare void @clearList(ptr)
-
-declare void @freeList(ptr)
-
-declare void @arraylist_add_ptr(ptr, ptr)
-
-declare i32 @length(ptr)
-
-declare ptr @arraylist_get_ptr(ptr, i64)
-
-declare void @arraylist_print_ptr(ptr, ptr)
-
-declare void @removeItem(ptr, i64)
-
-declare ptr @arraylist_create_int(i64)
-
-declare void @arraylist_add_int(ptr, i32)
-
-declare void @arraylist_addAll_int(ptr, ptr, i64)
-
-declare void @arraylist_print_int(ptr)
-
-declare void @arraylist_clear_int(ptr)
-
-declare void @arraylist_free_int(ptr)
-
-declare i32 @arraylist_get_int(ptr, i64, ptr)
-
-declare void @arraylist_remove_int(ptr, i64)
-
-declare i32 @arraylist_size_int(ptr)
-
-define void @print_Linha(ptr %p) {
-entry:
-  %v0 = load ptr, ptr %p, align 8
-  call void @arraylist_print_int(ptr %v0)
-  ret void
-}
-
-define void @print_Matriz(ptr %p) {
-entry:
-  ret void
-}
-
-define ptr @Matriz_addLinha(ptr %s, ptr %l) {
-entry:
-  %tmp2 = load ptr, ptr %s, align 8
-  call void @arraylist_add_ptr(ptr %tmp2, ptr %l)
-  ret ptr %s
-
-0:                                                ; No predecessors!
-  ret ptr %s
-}
-
-define ptr @Matriz_printMatriz(ptr %s) {
-entry:
-  %tmp116 = load ptr, ptr %s, align 8
-  %tmp137 = call i32 @length(ptr %tmp116)
-  %tmp148 = icmp slt i32 0, %tmp137
-  br i1 %tmp148, label %while_body_1.lr.ph, label %while_end_2
-
-while_body_1.lr.ph:                               ; preds = %entry
-  br label %while_body_1
-
-while_body_1:                                     ; preds = %while_body_1.lr.ph, %while_end_5
-  %i.09 = phi i32 [ 0, %while_body_1.lr.ph ], [ %tmp48, %while_end_5 ]
-  %ln = alloca ptr, align 8
-  %tmp17 = load ptr, ptr %s, align 8
-  %tmp19 = zext i32 %i.09 to i64
-  %tmp20 = call ptr @arraylist_get_ptr(ptr %tmp17, i64 %tmp19)
-  store ptr %tmp20, ptr %ln, align 8
-  %j = alloca i32, align 4
-  store i32 0, ptr %j, align 4
-  %tmp231 = load i32, ptr %j, align 4
-  %tmp272 = load ptr, ptr %ln, align 8
-  %tmp293 = load ptr, ptr %tmp272, align 8
-  %tmp304 = call i32 @arraylist_size_int(ptr %tmp293)
-  %tmp315 = icmp slt i32 %tmp231, %tmp304
-  br i1 %tmp315, label %while_body_4.lr.ph, label %while_end_5
-
-while_body_4.lr.ph:                               ; preds = %while_body_1
-  br label %while_body_4
-
-while_body_4:                                     ; preds = %while_body_4.lr.ph, %while_body_4
-  %tmp35 = load ptr, ptr %ln, align 8
-  %tmp37 = load ptr, ptr %tmp35, align 8
-  %tmp38 = load i32, ptr %j, align 4
-  %tmp39 = zext i32 %tmp38 to i64
-  %tmp40 = alloca i32, align 4
-  %tmp41 = call i32 @arraylist_get_int(ptr %tmp37, i64 %tmp39, ptr %tmp40)
-  %tmp42 = load i32, ptr %tmp40, align 4
-  %0 = call i32 (ptr, ...) @printf(ptr @.strInt_noNL, i32 %tmp42)
-  %1 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str0)
-  %tmp44 = load i32, ptr %j, align 4
-  %tmp45 = add i32 %tmp44, 1
-  store i32 %tmp45, ptr %j, align 4
-  %tmp23 = load i32, ptr %j, align 4
-  %tmp27 = load ptr, ptr %ln, align 8
-  %tmp29 = load ptr, ptr %tmp27, align 8
-  %tmp30 = call i32 @arraylist_size_int(ptr %tmp29)
-  %tmp31 = icmp slt i32 %tmp23, %tmp30
-  br i1 %tmp31, label %while_body_4, label %while_cond_3.while_end_5_crit_edge
-
-while_cond_3.while_end_5_crit_edge:               ; preds = %while_body_4
-  br label %while_end_5
-
-while_end_5:                                      ; preds = %while_cond_3.while_end_5_crit_edge, %while_body_1
-  %2 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str1)
-  %tmp48 = add i32 %i.09, 1
-  %tmp11 = load ptr, ptr %s, align 8
-  %tmp13 = call i32 @length(ptr %tmp11)
-  %tmp14 = icmp slt i32 %tmp48, %tmp13
-  br i1 %tmp14, label %while_body_1, label %while_cond_0.while_end_2_crit_edge
-
-while_cond_0.while_end_2_crit_edge:               ; preds = %while_end_5
-  br label %while_end_2
-
-while_end_2:                                      ; preds = %while_cond_0.while_end_2_crit_edge, %entry
-  ret ptr %s
-}
-
 define i32 @main() {
-  %tmp49 = call ptr @malloc(i64 8)
-  %tmp51 = call ptr @arraylist_create(i64 10)
-  store ptr %tmp51, ptr %tmp49, align 8
-  %tmp54 = call ptr @malloc(i64 8)
-  %tmp56 = call ptr @arraylist_create_int(i64 10)
-  store ptr %tmp56, ptr %tmp54, align 8
-  call void @arraylist_add_int(ptr %tmp56, i32 1)
-  %tmp72 = load ptr, ptr %tmp54, align 8
-  call void @arraylist_add_int(ptr %tmp72, i32 2)
-  %tmp80 = load ptr, ptr %tmp54, align 8
-  call void @arraylist_add_int(ptr %tmp80, i32 3)
-  call void @Matriz_addLinha(ptr %tmp49, ptr %tmp54)
-  %tmp84 = call ptr @malloc(i64 8)
-  %tmp86 = call ptr @arraylist_create_int(i64 10)
-  store ptr %tmp86, ptr %tmp84, align 8
-  call void @arraylist_add_int(ptr %tmp86, i32 4)
-  %tmp102 = load ptr, ptr %tmp84, align 8
-  call void @arraylist_add_int(ptr %tmp102, i32 5)
-  %tmp110 = load ptr, ptr %tmp84, align 8
-  call void @arraylist_add_int(ptr %tmp110, i32 6)
-  call void @Matriz_addLinha(ptr %tmp49, ptr %tmp84)
-  %tmp114 = call ptr @malloc(i64 8)
-  %tmp116 = call ptr @arraylist_create_int(i64 10)
-  store ptr %tmp116, ptr %tmp114, align 8
-  call void @arraylist_add_int(ptr %tmp116, i32 7)
-  %tmp132 = load ptr, ptr %tmp114, align 8
-  call void @arraylist_add_int(ptr %tmp132, i32 8)
-  %tmp140 = load ptr, ptr %tmp114, align 8
-  call void @arraylist_add_int(ptr %tmp140, i32 9)
-  call void @Matriz_addLinha(ptr %tmp49, ptr %tmp114)
-  call void @Matriz_printMatriz(ptr %tmp49)
-  %1 = call i32 @getchar()
+  %tmp153 = call double @sum(double 1.000000e+01, double 3.000000e+00)
+  %1 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp153)
+  %tmp156 = call double @sub(double 1.000000e+01, double 3.000000e+00)
+  %2 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp156)
+  %tmp159 = call double @mul(double 1.000000e+01, double 3.000000e+00)
+  %3 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp159)
+  %tmp162 = call double @div(double 1.000000e+01, double 3.000000e+00)
+  %4 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp162)
+  %tmp165 = call double @pow(double 1.000000e+01, i32 3)
+  %5 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp165)
+  %tmp167 = call i32 @factorial(i32 5)
+  %6 = call i32 (ptr, ...) @printf(ptr @.strInt, i32 %tmp167)
+  %tmp169 = call double @sqrt(double 1.000000e+01)
+  %7 = call i32 (ptr, ...) @printf(ptr @.strDouble, double 0x40094C583ADA5B53)
+  %tmp171 = call double @sin(double 1.000000e+01)
+  %8 = call i32 (ptr, ...) @printf(ptr @.strDouble, double 0xBFE1689EF5F34F52)
+  %tmp173 = call double @cos(double 1.000000e+01)
+  %9 = call i32 (ptr, ...) @printf(ptr @.strDouble, double 0xBFEAD9AC890C6B1F)
+  %10 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str4)
+  %tmp178 = call double @div(double 1.000000e+01, double 0.000000e+00)
+  %11 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp178)
+  %12 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str5)
+  %tmp181 = call i32 @factorial(i32 -3)
+  %13 = call i32 (ptr, ...) @printf(ptr @.strInt, i32 %tmp181)
+  %14 = call i32 (ptr, ...) @printf(ptr @.strStr, ptr @.str6)
+  %tmp185 = call double @sqrt(double -9.000000e+00)
+  %15 = call i32 (ptr, ...) @printf(ptr @.strDouble, double %tmp185)
+  %16 = call i32 (ptr, ...) @printf(ptr @.strStr_noNL, ptr @.str7)
+  %17 = call i32 @getchar()
   ret i32 0
 }

--- a/src/language/logics/matriz.zd
+++ b/src/language/logics/matriz.zd
@@ -1,0 +1,60 @@
+main {
+
+  Struct Linha {
+    List<int> valores;
+  }
+
+  Struct Matriz {
+    List<Linha> linhas;
+  }
+
+  impl Matriz {
+
+    function addLinha(Linha l) {
+      s.linhas.add(l);
+      return s;
+    }
+
+function printMatriz() {
+  int i = 0;
+  while (i < s.linhas.size()) {
+
+    Linha ln = s.linhas.get(i);
+
+    int j = 0;
+    while (j < ln.valores.size()) {
+      print(ln.valores.get(j));
+      print(" ");
+      j++;
+    }
+
+    println("");
+    i++;
+  }
+}
+
+
+  }
+
+  Matriz m;
+
+  Linha l0;
+  l0.valores.add(1);
+  l0.valores.add(2);
+  l0.valores.add(3);
+  m.addLinha(l0);
+
+  Linha l1;
+  l1.valores.add(4);
+  l1.valores.add(5);
+  l1.valores.add(6);
+  m.addLinha(l1);
+
+  Linha l2;
+  l2.valores.add(7);
+  l2.valores.add(8);
+  l2.valores.add(9);
+  m.addLinha(l2);
+
+  m.printMatriz();
+}

--- a/src/language/main.zd
+++ b/src/language/main.zd
@@ -1,60 +1,37 @@
+import "src/language/stdlib/Math.zd" as math;
+
 main {
-
-  Struct Linha {
-    List<int> valores;
-  }
-
-  Struct Matriz {
-    List<Linha> linhas;
-  }
-
-  impl Matriz {
-
-    function addLinha(Linha l) {
-      s.linhas.add(l);
-      return s;
-    }
-
-function printMatriz() {
-  int i = 0;
-  while (i < s.linhas.size()) {
-
-    Linha ln = s.linhas.get(i);
-
-    int j = 0;
-    while (j < ln.valores.size()) {
-      print(ln.valores.get(j));
-      print(" ");
-      j++;
-    }
-
-    println("");
-    i++;
-  }
-}
+    double a = 10;
+    double b = 3;
+    int n = 5;
 
 
-  }
+    println(math.sum(a, b));
+    println(math.sub(a, b));
+    println(math.mul(a, b));
+    println(math.div(a, b));
 
-  Matriz m;
 
-  Linha l0;
-  l0.valores.add(1);
-  l0.valores.add(2);
-  l0.valores.add(3);
-  m.addLinha(l0);
+    println(math.pow(a, 3));
 
-  Linha l1;
-  l1.valores.add(4);
-  l1.valores.add(5);
-  l1.valores.add(6);
-  m.addLinha(l1);
 
-  Linha l2;
-  l2.valores.add(7);
-  l2.valores.add(8);
-  l2.valores.add(9);
-  m.addLinha(l2);
+    println(math.factorial(n));
 
-  m.printMatriz();
+    println(math.sqrt(a));
+
+
+    println(math.sin(a));
+    println(math.cos(a));
+
+
+    println("Tentando dividir por zero:");
+    println(math.div(a, 0));
+
+    println("Tentando fatorial de número negativo:");
+    println(math.factorial(-3));
+
+    println("Tentando raiz quadrada de número negativo:");
+    println(math.sqrt(-9));
+
+    print("Fim dos testes.");
 }

--- a/src/low/prints/ExprPrintHandler.java
+++ b/src/low/prints/ExprPrintHandler.java
@@ -18,7 +18,9 @@ public class ExprPrintHandler {
         this.temps = temps;
     }
 
-    public String emitExprOrElement(String exprLLVM, LLVisitorMain visitor, ASTNode node, boolean newline) {
+    public String emitExprOrElement(String exprLLVM, LLVisitorMain visitor,
+                                    ASTNode node, boolean newline) {
+
         String valTypeLine = findLastValTypeMarkerOfExpression(exprLLVM);
         if (valTypeLine == null) return exprLLVM;
 
@@ -35,76 +37,109 @@ public class ExprPrintHandler {
         }
 
         switch (type) {
-            case "i32" -> appendPrintf(llvm, temp, newline, ".strInt");
-            case "double" -> appendPrintf(llvm, temp, newline, ".strDouble");
+
+            case "i32" ->
+                    appendPrintf(llvm, temp, newline, ".strInt", "i32");
+
+            case "double" ->
+                    appendPrintf(llvm, temp, newline, ".strDouble", "double");
+
             case "float" -> {
                 String tmpExt = temps.newTemp();
                 llvm.append("  ").append(tmpExt)
                         .append(" = fpext float ").append(temp).append(" to double\n")
                         .append(";;VAL:").append(tmpExt).append(";;TYPE:double\n");
-                appendPrintf(llvm, tmpExt, newline, ".strFloat");
+
+                appendPrintf(llvm, tmpExt, newline, ".strFloat", "double");
             }
-            case "i1" -> new PrimitivePrintHandler(temps).emitBoolPrint(llvm, temp, newline);
+
+            case "i1" ->
+                    new PrimitivePrintHandler(temps).emitBoolPrint(llvm, temp, newline);
+
             case "i8" -> {
                 String castTmp = temps.newTemp();
                 llvm.append("  ").append(castTmp)
-                        .append(" = sext i8 ").append(temp).append(" to i32\n");
-                appendPrintf(llvm, castTmp, newline, ".strChar");
+                        .append(" = sext i8 ").append(temp).append(" to i32\n")
+                        .append(";;VAL:").append(castTmp).append(";;TYPE:i32\n");
+
+                appendPrintf(llvm, castTmp, newline, ".strChar", "i32");
             }
+
             case "%String*" -> {
                 String fn = newline ? "@printString" : "@printString_noNL";
-                llvm.append("  call void ").append(fn).append("(%String* ").append(temp).append(")\n");
+                llvm.append("  call void ").append(fn)
+                        .append("(%String* ").append(temp).append(")\n");
             }
+
             case "i8*" -> {
                 if (node instanceof FunctionCallNode callNode) {
                     TypeInfos fnType = visitor.getFunctionType(callNode.getName());
                     if (fnType != null && fnType.isList()) {
-                        return new ListPrintHandler(temps).emit(node, visitor, newline);
+                        return new ListPrintHandler(temps)
+                                .emit(node, visitor, newline);
                     }
                 }
-                appendPrintf(llvm, temp, newline, ".strStr");
+                appendPrintf(llvm, temp, newline, ".strStr", "i8*");
             }
+
             default -> {
                 if (node instanceof ListSizeNode)
-                    return new ListSizePrintHandler(temps, new ListSizeEmitter(temps)).emit(node, visitor, newline);
+                    return new ListSizePrintHandler(
+                            temps, new ListSizeEmitter(temps))
+                            .emit(node, visitor, newline);
+
                 if (type.startsWith("%struct.ArrayList"))
-                    return new ListPrintHandler(temps).emit(node, visitor, newline);
-                if (node instanceof FunctionCallNode callNode && visitor.getFunctionType(callNode.getName()) != null
-                        && visitor.getFunctionType(callNode.getName()).isList()) {
-                    return new ListPrintHandler(temps).emit(node, visitor, newline);
+                    return new ListPrintHandler(temps)
+                            .emit(node, visitor, newline);
+
+                if (node instanceof FunctionCallNode callNode) {
+                    TypeInfos fnType = visitor.getFunctionType(callNode.getName());
+                    if (fnType != null && fnType.isList())
+                        return new ListPrintHandler(temps)
+                                .emit(node, visitor, newline);
                 }
+
                 if (node instanceof ListGetNode)
-                    return new ListGetPrintHandler(temps, new ListGetEmitter(temps)).emit(node, visitor, newline);
+                    return new ListGetPrintHandler(
+                            temps, new ListGetEmitter(temps))
+                            .emit(node, visitor, newline);
+
                 if (isStructLLVMType(type))
-                    return new StructPrintHandler(temps).emit(node, visitor, newline);
-                throw new RuntimeException("Unsupported type in print: " + type);
+                    return new StructPrintHandler(temps)
+                            .emit(node, visitor, newline);
+
+                throw new RuntimeException(
+                        "Unsupported type in print: " + type);
             }
         }
 
         return llvm.toString();
     }
 
-    private void appendPrintf(StringBuilder llvm, String temp, boolean newline, String strLabel) {
+    private void appendPrintf(StringBuilder llvm, String temp,
+                              boolean newline, String strLabel,
+                              String llvmType) {
+
         String label = newline ? strLabel : strLabel + "_noNL";
+
         llvm.append("  call i32 (i8*, ...) @printf(")
                 .append("i8* getelementptr ([")
                 .append(newline ? "4 x i8" : "3 x i8")
                 .append("], [")
                 .append(newline ? "4 x i8" : "3 x i8")
                 .append("]* @").append(label)
-                .append(", i32 0, i32 0), ").append(getLLVMType(temp)).append(" ").append(temp).append(")\n");
+                .append(", i32 0, i32 0), ")
+                .append(llvmType).append(" ").append(temp).append(")\n");
     }
 
-    private String getLLVMType(String temp) {
-        // Para simplicidade assumimos que temp já possui tipo correto extraído
-        return "i32";
-    }
+    /* ================= helpers ================= */
 
     private String findLastValTypeMarkerOfExpression(String exprLLVM) {
         String[] lines = exprLLVM.split("\n");
         for (int i = lines.length - 1; i >= 0; i--) {
             String line = lines[i].trim();
-            if (line.startsWith(";;VAL:") && line.contains(";;TYPE:")) return line;
+            if (line.startsWith(";;VAL:") && line.contains(";;TYPE:"))
+                return line;
         }
         return null;
     }
@@ -112,16 +147,12 @@ public class ExprPrintHandler {
     private String extractTemp(String valTypeLine) {
         int v = valTypeLine.indexOf(";;VAL:");
         int t = valTypeLine.indexOf(";;TYPE:", v);
-        if (v == -1 || t == -1) return "";
         return valTypeLine.substring(v + 6, t).trim();
     }
 
     private String extractType(String valTypeLine) {
         int t = valTypeLine.indexOf(";;TYPE:");
-        if (t == -1) return "";
-        int end = valTypeLine.indexOf("\n", t);
-        if (end == -1) end = valTypeLine.length();
-        return valTypeLine.substring(t + 7, end).trim();
+        return valTypeLine.substring(t + 7).trim();
     }
 
     private boolean isStructLLVMType(String llvmType) {
@@ -129,6 +160,8 @@ public class ExprPrintHandler {
         String t = llvmType.trim();
         while (t.endsWith("*")) t = t.substring(0, t.length() - 1);
         if (t.startsWith("%")) t = t.substring(1);
-        return !t.isEmpty() && Character.isUpperCase(t.charAt(0)) && !t.equals("String");
+        return !t.isEmpty()
+                && Character.isUpperCase(t.charAt(0))
+                && !t.equals("String");
     }
 }


### PR DESCRIPTION
ExprPrintHandler was incorrectly forcing printf arguments to i32, causing LLVM IR type mismatches when printing expressions that evaluate to double, float, or other non-integer types.

This commit fixes the issue by:
- Using the ;;TYPE metadata extracted from expressions to determine the correct LLVM type to pass to printf
- Removing implicit assumptions that expression temps are i32
- Ensuring printf format strings and argument types always match
- Extending float values to double explicitly before printing