### PR TITLE
 refactor(lists,ownership): separate AST DynamicList from runtime Lis…

### DIFF
--- a/src/ast/lists/DynamicList.java
+++ b/src/ast/lists/DynamicList.java
@@ -8,82 +8,25 @@ import ast.variables.LiteralNode;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DynamicList {
+public final class DynamicList {
+
     private final List<ASTNode> elements;
-    private  String elementType;
+    private String elementType; // "?" até o bind()
 
     public DynamicList(String elementType, List<ASTNode> elements) {
         this.elementType = elementType;
         this.elements = elements;
     }
 
-    public String getElementType() {
-        return elementType;
-    }
-
     public List<ASTNode> getElements() {
         return elements;
     }
 
-    // Avalia todos os elementos no runtime
-    public List<TypedValue> evaluate(RuntimeContext ctx) {
-        List<TypedValue> result = new ArrayList<>();
-        for (ASTNode node : elements) {
-            result.add(node.evaluate(ctx));
-        }
-        return result;
+    public String getElementType() {
+        return elementType;
     }
 
-    public TypedValue get(int index, RuntimeContext ctx) {
-        return elements.get(index).evaluate(ctx);
+    public void lockElementType(String type) {
+        this.elementType = type;
     }
-
-    public TypedValue removeByIndex(int index, RuntimeContext ctx) {
-        ASTNode removedNode = elements.remove(index);
-        return removedNode.evaluate(ctx);
-    }
-    public void add(TypedValue value) {
-        String valType = value.type();
-
-        if (elementType.equals("?") || elementType.equals("any")) {
-            if (elements.isEmpty()) {
-                // trava o tipo dessa lista na primeira inserção
-                this.elementType = valType;
-            } else if (!valType.equals(this.elementType)) {
-                throw new RuntimeException(
-                        "Tipo inválido para lista <" + elementType + ">: " + valType
-                );
-            }
-
-            elements.add(new LiteralNode(value));
-            return;
-        }
-
-        boolean ok = valType.equals(elementType);
-
-        if (!ok && valType.startsWith("Struct<")) {
-            String inner = valType.substring("Struct<".length(), valType.length() - 1);
-            if (inner.equals(elementType)) {
-                ok = true;
-            }
-        }
-
-        if (!ok) {
-            throw new RuntimeException("Tipo inválido para lista <" + elementType + ">: " + valType);
-        }
-
-        elements.add(new LiteralNode(value));
-    }
-
-    public int size() {
-        return elements.size();
-    }
-
-    @Override
-    public String toString() {
-        List<TypedValue> vals = evaluate(new RuntimeContext()); // opcional para debug
-        return vals.toString();
-    }
-
-
 }

--- a/src/ast/lists/ListAddAllNode.java
+++ b/src/ast/lists/ListAddAllNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 import java.util.List;
@@ -31,27 +32,25 @@ public class ListAddAllNode extends ASTNode {
         return visitor.visit(this);
     }
 
-    @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        DynamicList target = (DynamicList) targetListNode.evaluate(ctx).value();
 
-        for (ASTNode argNode : args) {
-            TypedValue val = argNode.evaluate(ctx);
+        ListValue target = (ListValue) targetListNode.evaluate(ctx).value();
 
-            if (val.type().equals("List")) {
-                // Se for uma lista, adiciona cada elemento
-                DynamicList other = (DynamicList) val.value();
-                for (ASTNode elemNode : other.getElements()) {
-                    target.add(elemNode.evaluate(ctx));
+        for (ASTNode arg : args) {
+            TypedValue tv = arg.evaluate(ctx);
+
+            if (tv.value() instanceof ListValue other) {
+                for (int i = 0; i < other.size(); i++) {
+                    target.add(other.get(i));
                 }
             } else {
-                // Se for valor simples, adiciona direto
-                target.add(val);
+                target.add(tv);
             }
         }
 
-        return new TypedValue("List", target);
+        return new TypedValue("List<" + target.getElementType() + ">", target);
     }
+
 
     @Override
     public void print(String prefix) {

--- a/src/ast/lists/ListAddNode.java
+++ b/src/ast/lists/ListAddNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 import java.util.List;
@@ -29,7 +30,7 @@ public class ListAddNode extends ASTNode {
 
     @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        DynamicList list = (DynamicList) listNode.evaluate(ctx).value();
+        ListValue list = new ListValue(listNode.getType());
         TypedValue values = valuesNode.evaluate(ctx);
         list.add(values);
         return values;

--- a/src/ast/lists/ListClearNode.java
+++ b/src/ast/lists/ListClearNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 public class ListClearNode extends ASTNode {
@@ -23,10 +24,12 @@ public class ListClearNode extends ASTNode {
 
     @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        DynamicList list = (DynamicList) listNode.evaluate(ctx).value();
-        list.getElements().clear();
-        return new TypedValue("List", list);
+        ListValue list = (ListValue) listNode.evaluate(ctx).value();
+
+        list.clear();
+        return new TypedValue("List<" + list.getElementType() + ">", list);
     }
+
 
 
     public ASTNode getListNode() {

--- a/src/ast/lists/ListGetNode.java
+++ b/src/ast/lists/ListGetNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 public class ListGetNode extends ASTNode {
@@ -32,11 +33,13 @@ public class ListGetNode extends ASTNode {
 
     @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        DynamicList list = (DynamicList) listName.evaluate(ctx).value();
-        int index = ((Number) indexNode.evaluate(ctx).value()).intValue();
-        return list.get(index, ctx);
-    }
 
+        ListValue list = (ListValue) listName.evaluate(ctx).value();
+
+        int index = ((Number) indexNode.evaluate(ctx).value()).intValue();
+
+        return list.get(index);
+    }
     @Override
     public void print(String prefix) {
         System.out.println(prefix + "ListGet:");

--- a/src/ast/lists/ListRemoveNode.java
+++ b/src/ast/lists/ListRemoveNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 public class ListRemoveNode extends ASTNode {
@@ -23,9 +24,12 @@ public class ListRemoveNode extends ASTNode {
 
     @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        DynamicList list = (DynamicList) listNode.evaluate(ctx).value();
+
+        ListValue list = (ListValue) listNode.evaluate(ctx).value();
+
         int index = ((Number) indexNode.evaluate(ctx).value()).intValue();
-        return list.removeByIndex(index, ctx); // usa método novo
+
+        return list.removeByIndex(index);
     }
 
     public ASTNode getIndexNode() {

--- a/src/ast/lists/ListSizeNode.java
+++ b/src/ast/lists/ListSizeNode.java
@@ -4,6 +4,7 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.list.ListValue;
 import low.module.LLVMEmitVisitor;
 
 public class ListSizeNode extends ASTNode {
@@ -21,17 +22,10 @@ public class ListSizeNode extends ASTNode {
 
     @Override
     public TypedValue evaluate(RuntimeContext ctx) {
-        // Avalia o ASTNode para obter o valor
-        TypedValue listVal = nome.evaluate(ctx);
 
-        if (!listVal.type().startsWith("List")) {
-            throw new RuntimeException("O valor avaliado não é uma lista");
-        }
+        ListValue list = (ListValue)nome.evaluate(ctx).value();
 
-        DynamicList dynamicList = (DynamicList) listVal.value();
-        int size = dynamicList.size();
-
-        return new TypedValue("int", size);
+        return new TypedValue("int", list.size());
     }
 
     public ASTNode getNome() {

--- a/src/ast/structs/StructNode.java
+++ b/src/ast/structs/StructNode.java
@@ -2,8 +2,8 @@ package ast.structs;
 
 import ast.ASTNode;
 import context.statics.StaticContext;
-import context.statics.StaticFields;
-import context.statics.StaticStructDefinition;
+import context.statics.structs.StaticFields;
+import context.statics.structs.StaticStructDefinition;
 import ast.expressions.TypedValue;
 import context.runtime.RuntimeContext;
 import ast.variables.VariableDeclarationNode;

--- a/src/ast/variables/VariableNode.java
+++ b/src/ast/variables/VariableNode.java
@@ -4,34 +4,14 @@ import ast.ASTNode;
 import context.runtime.RuntimeContext;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
+import context.statics.Symbol;
 import low.module.LLVMEmitVisitor;
-
 public class VariableNode extends ASTNode {
     public final String name;
-    
+    private Symbol symbol; // ← símbolo resolvido
+
     public VariableNode(String name) {
         this.name = name;
-    }
-
-    @Override
-    public String accept(LLVMEmitVisitor visitor) {
-        return visitor.visit(this);
-    }
-
-
-    @Override
-    public TypedValue evaluate(RuntimeContext ctx) {
-        return ctx.getVariable(name);
-    }
-
-    @Override
-    public void print(String prefix) {
-        System.out.println(prefix + "Variable: " + name);
-    }
-
-    @Override
-    public void bind(StaticContext stx) {
-        stx.resolveVariable(name);
     }
 
     public String getName() {
@@ -39,9 +19,32 @@ public class VariableNode extends ASTNode {
     }
 
     @Override
-    public String toString() {
-        return "VariableNode{" +
-                "name='" + name + '\'' +
-                '}';
+    public void bind(StaticContext stx) {
+        this.symbol = stx.resolveVariable(name);
+    }
+
+    @Override
+    public String getType() {
+        return symbol.getType();
+    }
+
+    public Symbol getSymbol() {
+        return symbol;
+    }
+
+    @Override
+    public TypedValue evaluate(RuntimeContext ctx) {
+        return ctx.getVariable(name);
+    }
+
+    @Override
+    public String accept(LLVMEmitVisitor visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public void print(String prefix) {
+        System.out.println(prefix + "Variable: " + name +
+                (symbol != null ? " : " + symbol.getType() : ""));
     }
 }

--- a/src/context/statics/StaticContext.java
+++ b/src/context/statics/StaticContext.java
@@ -1,5 +1,7 @@
 package context.statics;
 
+import context.statics.structs.StaticStructDefinition;
+
 import java.util.*;
 
 public class StaticContext {

--- a/src/context/statics/Symbol.java
+++ b/src/context/statics/Symbol.java
@@ -1,5 +1,4 @@
 package context.statics;
-
 public class Symbol {
     private final String name;
     private final String type;
@@ -11,6 +10,18 @@ public class Symbol {
         this.type = type;
         this.slotIndex = slotIndex;
         this.declaredIn = declaredIn;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getSlotIndex() {
+        return slotIndex;
     }
 
     public StaticContext getDeclaredIn() {

--- a/src/context/statics/list/ListValue.java
+++ b/src/context/statics/list/ListValue.java
@@ -1,0 +1,62 @@
+package context.statics.list;
+
+import ast.expressions.TypedValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public final class ListValue {
+
+    private final UUID id = UUID.randomUUID();
+    private final String elementType;
+    private final List<TypedValue> elements = new ArrayList<>();
+
+    public ListValue(String elementType) {
+        this.elementType = elementType;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getElementType() {
+        return elementType;
+    }
+
+    public void add(TypedValue value) {
+        if (!value.type().equals(elementType)) {
+            throw new RuntimeException(
+                    "Tipo inválido para lista <" + elementType + ">: " + value.type()
+            );
+        }
+        elements.add(value);
+    }
+
+    public TypedValue get(int index) {
+        if (index < 0 || index >= elements.size()) {
+            throw new RuntimeException("Índice inválido: " + index);
+        }
+        return elements.get(index);
+    }
+
+    public TypedValue removeByIndex(int index) {
+        if (index < 0 || index >= elements.size()) {
+            throw new RuntimeException("Índice inválido: " + index);
+        }
+        return elements.remove(index);
+    }
+
+    public int size() {
+        return elements.size();
+    }
+
+    @Override
+    public String toString() {
+        return elements.toString();
+    }
+
+    public void clear() {
+        elements.clear();
+    }
+}

--- a/src/context/statics/structs/StaticFields.java
+++ b/src/context/statics/structs/StaticFields.java
@@ -1,4 +1,4 @@
-package context.statics;
+package context.statics.structs;
 
 public class StaticFields {
     private final String name;

--- a/src/context/statics/structs/StaticStructDefinition.java
+++ b/src/context/statics/structs/StaticStructDefinition.java
@@ -1,4 +1,4 @@
-package context.statics;
+package context.statics.structs;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/low/imports/ImportEmitter.java
+++ b/src/low/imports/ImportEmitter.java
@@ -137,7 +137,7 @@ public class ImportEmitter {
             if (v.getType().startsWith("List<")) {
                 tiposDeListasUsados.add(v.getType());
             }
-            if (v.initializer != null) coletarListas(v.initializer);
+            if (v.getInitializer() != null) coletarListas(v.getInitializer());
         }
 
         if (node instanceof ListNode list) {


### PR DESCRIPTION
…tValue and improve move diagnostics

- Split list representation into:
  - DynamicList (AST / compile-time structure)
  - ListValue (runtime value with strict element typing)
- Updated ListNode to evaluate into ListValue instead of reusing AST list
- Fixed list type inference and validation during bind phase
- Enforced explicit type for empty list declarations
- Aligned VariableDeclarationNode to initialize ListValue properly

Ownership analysis improvements:
- Enhanced OwnershipAnalyzer to track move targets precisely
- ListAdd now reports MOVE <var> -> <list name>
- StructFieldAssignment now reports MOVE <var> -> <struct.field>
- Added structural path resolution for nested struct field moves
- Improved debug logs to reflect real ownership flow

This prepares the compiler for correct memory ownership propagation and future free-insertion passes without runtime aliasing bugs