### PR TITLE
Refactor: Lifetime & Free Planning based on Symbol and StaticContext

### DIFF
--- a/src/ast/ASTNode.java
+++ b/src/ast/ASTNode.java
@@ -7,13 +7,32 @@ import low.module.LLVMEmitVisitor;
 
 import java.util.Collections;
 import java.util.List;
+
+
 public abstract class ASTNode {
-    
+
+    private StaticContext staticContext;
+
     public boolean isStatement() {
         return false;
     }
 
+    public final void bind(StaticContext ctx) {
+        this.staticContext = ctx;
+        bindChildren(ctx);
+    }
 
+    protected void bindChildren(StaticContext ctx) {
+        for (ASTNode child : getChildren()) {
+            if (child != null) {
+                child.bind(ctx);
+            }
+        }
+    }
+
+    public StaticContext getStaticContext() {
+        return staticContext;
+    }
 
     public abstract String accept(LLVMEmitVisitor visitor);
     public abstract TypedValue evaluate(RuntimeContext ctx);
@@ -25,11 +44,5 @@ public abstract class ASTNode {
 
     public String getType() {
         return null;
-    }
-
-    public void bind(StaticContext stx) {
-        for (ASTNode child : getChildren()) {
-            child.bind(stx);
-        }
     }
 }

--- a/src/ast/exceptions/BreakNode.java
+++ b/src/ast/exceptions/BreakNode.java
@@ -24,7 +24,7 @@ public class BreakNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/exceptions/ReturnNode.java
+++ b/src/ast/exceptions/ReturnNode.java
@@ -40,7 +40,7 @@ public class ReturnNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
         if(expr != null) {
         expr.bind(stx);
         }

--- a/src/ast/functions/FunctionCallNode.java
+++ b/src/ast/functions/FunctionCallNode.java
@@ -63,7 +63,7 @@ public class FunctionCallNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/functions/FunctionNode.java
+++ b/src/ast/functions/FunctionNode.java
@@ -72,7 +72,7 @@ public class FunctionNode extends ASTNode {
         return body;
     }
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
         StaticContext funcCtx =
                 new StaticContext(ScopeKind.FUNCTION, stx);

--- a/src/ast/functions/FunctionReferenceNode.java
+++ b/src/ast/functions/FunctionReferenceNode.java
@@ -46,7 +46,7 @@ public class FunctionReferenceNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/home/MainAST.java
+++ b/src/ast/home/MainAST.java
@@ -49,12 +49,11 @@ public class MainAST extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext parent) {
-        for (ASTNode n : body) {
-            n.bind(parent);
+    protected void bindChildren(StaticContext ignored) {
+        StaticContext global = new StaticContext(ScopeKind.GLOBAL);
+        for (ASTNode stmt : body) {
+            stmt.bind(global);
         }
     }
-
-
 
 }

--- a/src/ast/ifstatements/IfNode.java
+++ b/src/ast/ifstatements/IfNode.java
@@ -2,6 +2,7 @@ package ast.ifstatements;
 
 import ast.ASTNode;
 import context.runtime.RuntimeContext;
+import context.statics.ScopeKind;
 import context.statics.StaticContext;
 import ast.expressions.TypedValue;
 import low.module.LLVMEmitVisitor;
@@ -95,7 +96,30 @@ public class IfNode extends ASTNode {
 
 
     @Override
-    public void bind(StaticContext stx) {
+    protected void bindChildren(StaticContext parent) {
 
+        // condição usa o mesmo escopo
+        if (condition != null) {
+            condition.bind(parent);
+        }
+
+        // then cria escopo condicional
+        StaticContext thenCtx =
+                new StaticContext(ScopeKind.IF_THEN, parent);
+
+        for (ASTNode node : thenBranch) {
+            node.bind(thenCtx);
+        }
+
+        if (elseBranch != null) {
+            StaticContext elseCtx =
+                    new StaticContext(ScopeKind.IF_ELSE, parent);
+
+            for (ASTNode node : elseBranch) {
+                node.bind(elseCtx);
+            }
+        }
     }
+
+
 }

--- a/src/ast/imports/ImportNode.java
+++ b/src/ast/imports/ImportNode.java
@@ -151,7 +151,7 @@ public class ImportNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/lists/ListAddAllNode.java
+++ b/src/ast/lists/ListAddAllNode.java
@@ -64,7 +64,7 @@ public class ListAddAllNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/lists/ListAddNode.java
+++ b/src/ast/lists/ListAddNode.java
@@ -54,7 +54,7 @@ public class ListAddNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/lists/ListClearNode.java
+++ b/src/ast/lists/ListClearNode.java
@@ -45,7 +45,7 @@ public class ListClearNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/lists/ListGetNode.java
+++ b/src/ast/lists/ListGetNode.java
@@ -48,7 +48,7 @@ public class ListGetNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/lists/ListNode.java
+++ b/src/ast/lists/ListNode.java
@@ -29,7 +29,7 @@ public final class ListNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    protected void bindChildren(StaticContext stx) {
 
         for (ASTNode node : list.getElements()) {
             node.bind(stx);
@@ -38,7 +38,9 @@ public final class ListNode extends ASTNode {
         if (list.getElementType().equals("?")) {
 
             if (list.getElements().isEmpty()) {
-                throw new RuntimeException("Lista vazia sem tipo explícito");
+                throw new RuntimeException(
+                        "Lista vazia sem tipo explícito"
+                );
             }
 
             ASTNode first = list.getElements().get(0);
@@ -53,9 +55,7 @@ public final class ListNode extends ASTNode {
             list.lockElementType(inferredType);
         }
 
-        String expected = getString();
-
-        this.type = "List<" + expected + ">";
+        this.type = "List<" + list.getElementType() + ">";
     }
 
     private String getString() {

--- a/src/ast/lists/ListRemoveNode.java
+++ b/src/ast/lists/ListRemoveNode.java
@@ -45,7 +45,7 @@ public class ListRemoveNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/lists/ListSizeNode.java
+++ b/src/ast/lists/ListSizeNode.java
@@ -39,7 +39,7 @@ public class ListSizeNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/loops/ForNode.java
+++ b/src/ast/loops/ForNode.java
@@ -117,7 +117,7 @@ public class ForNode extends ASTNode {
 
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
         StaticContext forCtx = childScope(ScopeKind.FOR, stx);
 

--- a/src/ast/loops/WhileNode.java
+++ b/src/ast/loops/WhileNode.java
@@ -74,16 +74,15 @@ public class WhileNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
-        StaticContext whileContext = childScope(ScopeKind.WHILE, stx);
+    protected void bindChildren(StaticContext parent) {
 
-        if (condition != null)
-            condition.bind(whileContext);
+        condition.bind(parent);
 
-        StaticContext bodyContext = childScope(ScopeKind.BLOCK, whileContext);
+        StaticContext loopCtx = new StaticContext(ScopeKind.WHILE, parent);
 
-        for (ASTNode node : body)
-            node.bind(bodyContext);
+        for (ASTNode stmt : body) {
+            stmt.bind(loopCtx);
+        }
     }
 
     @Override

--- a/src/ast/prints/PrintNode.java
+++ b/src/ast/prints/PrintNode.java
@@ -76,7 +76,7 @@ public class PrintNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
         expr.bind(stx);
     }
 }

--- a/src/ast/structs/ImplNode.java
+++ b/src/ast/structs/ImplNode.java
@@ -50,7 +50,7 @@ public class ImplNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/structs/StructFieldAccessNode.java
+++ b/src/ast/structs/StructFieldAccessNode.java
@@ -79,7 +79,7 @@ public class StructFieldAccessNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/structs/StructInstanceNode.java
+++ b/src/ast/structs/StructInstanceNode.java
@@ -184,7 +184,7 @@ public class StructInstanceNode extends ASTNode {
         return list;
     }
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
         StaticStructDefinition def = stx.resolveStruct(structName);
 

--- a/src/ast/structs/StructMethodCallNode.java
+++ b/src/ast/structs/StructMethodCallNode.java
@@ -96,7 +96,7 @@ public class StructMethodCallNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/structs/StructNode.java
+++ b/src/ast/structs/StructNode.java
@@ -79,7 +79,7 @@ public class StructNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
         Set<String> seen = new HashSet<>();
         for (VariableDeclarationNode f : fields) {

--- a/src/ast/structs/StructUpdateNode.java
+++ b/src/ast/structs/StructUpdateNode.java
@@ -101,7 +101,7 @@ public class StructUpdateNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/variables/AssignmentNode.java
+++ b/src/ast/variables/AssignmentNode.java
@@ -60,7 +60,7 @@ public class AssignmentNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 }

--- a/src/ast/variables/BinaryOpNode.java
+++ b/src/ast/variables/BinaryOpNode.java
@@ -105,7 +105,7 @@ public class BinaryOpNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/variables/LiteralNode.java
+++ b/src/ast/variables/LiteralNode.java
@@ -17,7 +17,7 @@ public class LiteralNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/variables/UnaryOpNode.java
+++ b/src/ast/variables/UnaryOpNode.java
@@ -66,7 +66,7 @@ public class UnaryOpNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
 
     }
 

--- a/src/ast/variables/VariableDeclarationNode.java
+++ b/src/ast/variables/VariableDeclarationNode.java
@@ -126,11 +126,18 @@ public class VariableDeclarationNode extends ASTNode {
 
 
     @Override
-    public void bind(StaticContext stx) {
-        stx.declareVariable(name, type);
+    public void bindChildren(StaticContext ctx) {
+
+        ctx.declareVariable(name, type);
+
         if (initializer != null) {
-            initializer.bind(stx);
+            initializer.bind(ctx);
         }
+    }
+
+    @Override
+    public boolean isStatement() {
+        return true;
     }
 
     @Override
@@ -146,12 +153,6 @@ public class VariableDeclarationNode extends ASTNode {
     public List<ASTNode> getChildren() {
         if (initializer == null) return List.of();
         return List.of(initializer);
-    }
-
-
-    @Override
-    public boolean isStatement() {
-        return true;
     }
 
     public String getName() {

--- a/src/ast/variables/VariableNode.java
+++ b/src/ast/variables/VariableNode.java
@@ -19,7 +19,7 @@ public class VariableNode extends ASTNode {
     }
 
     @Override
-    public void bind(StaticContext stx) {
+    public void bindChildren(StaticContext stx) {
         this.symbol = stx.resolveVariable(name);
     }
 

--- a/src/context/statics/ScopeKind.java
+++ b/src/context/statics/ScopeKind.java
@@ -1,12 +1,63 @@
 package context.statics;
 
+
 public enum ScopeKind {
 
-    GLOBAL,
-    FUNCTION,
-    BLOCK,
-    IF,
-    WHILE,
-    FOR,
-    STRUCT
+    // Raiz do programa
+    GLOBAL(false, false),
+
+    // Função sempre cria boundary forte
+    FUNCTION(true, false),
+    ROOT(false,false ),
+    // Bloco simples (ex: { ... })
+    BLOCK(true, false),
+
+    // If como nó lógico (não usado diretamente para variáveis)
+    IF(false, true),
+
+    // Ramos reais do if (onde variáveis vivem)
+    IF_THEN(true, true),
+    IF_ELSE(true, true),
+
+    // Loops
+    WHILE(true, true),
+    FOR(true, true),
+
+    // Definição de struct (escopo de tipo, não de execução)
+    STRUCT(false, false);
+
+    /** Este escopo define um limite de lifetime? */
+    private final boolean lifetimeBoundary;
+
+    /** Este escopo faz parte de controle de fluxo? */
+    private final boolean controlFlow;
+
+    ScopeKind(boolean lifetimeBoundary, boolean controlFlow) {
+        this.lifetimeBoundary = lifetimeBoundary;
+        this.controlFlow = controlFlow;
+    }
+
+    public boolean hasLifetimeBoundary() {
+        return lifetimeBoundary;
+    }
+
+    public boolean isControlFlow() {
+        return controlFlow;
+    }
+
+    public boolean isLoop() {
+        return this == WHILE || this == FOR;
+    }
+
+    public boolean isConditional() {
+        return this == IF || this == IF_THEN || this == IF_ELSE;
+    }
+
+    public boolean isFunction() {
+        return this == FUNCTION;
+    }
+
+    public boolean isBlockLike() {
+        return lifetimeBoundary && !controlFlow;
+    }
 }

--- a/src/context/statics/Symbol.java
+++ b/src/context/statics/Symbol.java
@@ -1,5 +1,7 @@
 package context.statics;
-public class Symbol {
+
+public final class Symbol {
+
     private final String name;
     private final String type;
     private final int slotIndex;
@@ -11,6 +13,7 @@ public class Symbol {
         this.slotIndex = slotIndex;
         this.declaredIn = declaredIn;
     }
+
 
     public String getName() {
         return name;
@@ -32,11 +35,30 @@ public class Symbol {
         return declaredIn.getKind();
     }
 
+    public int getDeclarationDepth() {
+        return declaredIn.getDepth();
+    }
+
+
+    public boolean isGlobal() {
+        return declaredIn.getKind() == ScopeKind.GLOBAL;
+    }
+
+    public boolean isLocalTo(StaticContext ctx) {
+        return declaredIn.isAncestorOf(ctx);
+    }
+
+    public boolean diesAtScopeExit(StaticContext ctx) {
+        return isLocalTo(ctx) && ctx.hasLifetimeBoundary();
+    }
+
+
     @Override
     public String toString() {
         return name + ":" + type +
                 " (slot " + slotIndex + ")" +
                 " declared in " + declaredIn.getKind() +
-                " [scope #" + declaredIn.getId() + "]";
+                " [scope #" + declaredIn.getId() +
+                ", depth=" + declaredIn.getDepth() + "]";
     }
 }

--- a/src/context/statics/structs/StaticFields.java
+++ b/src/context/statics/structs/StaticFields.java
@@ -1,6 +1,6 @@
 package context.statics.structs;
+public final class StaticFields {
 
-public class StaticFields {
     private final String name;
     private final String type;
     private final int index;

--- a/src/context/statics/structs/StaticStructDefinition.java
+++ b/src/context/statics/structs/StaticStructDefinition.java
@@ -2,8 +2,7 @@ package context.statics.structs;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-public class StaticStructDefinition {
+import java.util.Map;public final class StaticStructDefinition {
 
     private final String name;
     private final List<StaticFields> fields;
@@ -32,11 +31,11 @@ public class StaticStructDefinition {
         return fields;
     }
 
-    public StaticFields getField(String name) {
-        StaticFields f = fieldMap.get(name);
+    public StaticFields getField(String fieldName) {
+        StaticFields f = fieldMap.get(fieldName);
         if (f == null) {
             throw new RuntimeException(
-                    "Campo não existe no struct " + this.name + ": " + name
+                    "Campo não existe no struct " + name + ": " + fieldName
             );
         }
         return f;

--- a/src/language/main.zd
+++ b/src/language/main.zd
@@ -1,14 +1,101 @@
 main {
-int x = 10;
-while ( x > 0 ) {
-List nomes =("zard");
-print(nomes);
-if(x == 4) {
-   List teste = ("angel");
-    print(teste);
-}
-x--;
+function void bubbleSort(List<int> arr) {
+
+    # Guarda o tamanho inicial da lista
+    int n = arr.size();
+
+    # Variável externa do laço do Bubble Sort
+    int i = 0;
+
+    # Loop externo → controla quantas passagens já fizemos
+    while (i < n - 1) {
+
+        # Loop interno (comparações adjacentes)
+        int j = 0;
+
+        while (j < n - i - 1) {
+
+            # Pega o elemento atual
+            int a = arr.get(j);
+
+            # Pega o próximo elemento
+            int b = arr.get(j+1);
+
+            # Se estão fora de ordem → precisamos trocar
+            if (a > b) {
+
+                # ETAPA 1 — Remover os dois
+
+                # Remove o elemento 'a' na posição j
+                arr.remove(j);
+
+                # Agora o antigo b passou a ser o índice j,
+                # então remover j novamente remove b
+                arr.remove(j);
+
+                # ETAPA 2 — Criar lista temporária
+
+                # Lista temporária para reconstruir os valores
+                List<int> temp;
+
+                # Copiar todos os elementos anteriores a j
+                int k = 0;
+                while (k < j) {
+                    temp.add(arr.get(k));   # copia início
+                    k++;
+                }
+
+                # Inserir primeiro o menor (b)
+                temp.add(b);
+
+                # Depois o maior (a)
+                temp.add(a);
+
+                # Copiar os elementos que ficaram após j
+                while (k < arr.size()) {
+                    temp.add(arr.get(k));
+                    k++;
+                }
+
+                # ============================
+                # ETAPA 3 — Substituir arr pelo temp
+                # ============================
+
+                # Limpar a lista original
+                arr.clear();
+
+                # Reiniciar k
+                k = 0;
+
+                # Recolocar tudo de temp para arr
+                while (k < temp.size()) {
+                    arr.add(temp.get(k));
+                    k++;
+                }
+            }
+
+            # Próxima comparação
+            j++;
+        }
+
+        # Passagem completa do bubble sort
+        i++;
+    }
 }
 
+
+  # Exemplo de lista
+  int j =0;
+    List<int> nums = (5, 1, 4, 2, 8);
+   println(nums.get(j+2));
+   call  bubbleSort(nums);
+
+    println("Lista ordenada:");
+    int i = 0;
+    println(nums);
+    while (i < nums.size()) {
+        println(nums.get(i));
+        i++;
+    }
 
 }

--- a/src/memory_manager/free/FreePlanner.java
+++ b/src/memory_manager/free/FreePlanner.java
@@ -41,43 +41,38 @@ public class FreePlanner {
 
         return result;
     }
-
     private void planRoot(OwnershipNode root, Map<ASTNode, List<FreeAction>> result) {
-
         String var = root.getId();
 
-        if (alreadyPlanned.contains(var)) {
-            return;
-        }
+        if (alreadyPlanned.contains(var)) return;
         alreadyPlanned.add(var);
 
-        // Ignora se a variável escapou
         if (escapeInfo != null && escapeInfo.escapes(var)) {
+            System.out.println("[FREE PLANNER] " + var + " escapa, não libera.");
             return;
         }
 
-        // Ignora se a variável foi movida
         if (wasMoved(var)) {
+            System.out.println("[FREE PLANNER] " + var + " foi movida, não libera.");
             return;
         }
 
-        // Obtém o nó de último uso
         ASTNode anchor = lastUseNode.get(var);
         if (anchor == null) {
-            // Se não houver uso, podemos liberar logo na declaração ou ignorar
+            System.out.println("[FREE PLANNER] " + var + " não tem uso, ignora.");
             return;
         }
 
-        // Adiciona FreeAction imediatamente após o último uso
-        result
-                .computeIfAbsent(anchor, k -> new ArrayList<>())
+        result.computeIfAbsent(anchor, k -> new ArrayList<>())
                 .add(new FreeAction(anchor, root));
 
-        // Planeja recursivamente para filhos (campos de structs / listas internas)
+        System.out.println("[FREE PLANNER] Planejando free para " + var + " após " + anchor.getClass().getSimpleName());
+
         for (OwnershipNode child : root.getChildren()) {
             planRoot(child, result);
         }
     }
+
 
     private boolean wasMoved(String var) {
         for (OwnershipAnnotation ann : annotations) {

--- a/src/memory_manager/lifetime/DeterministicLifetimeAnalyzer.java
+++ b/src/memory_manager/lifetime/DeterministicLifetimeAnalyzer.java
@@ -1,5 +1,8 @@
 package memory_manager.lifetime;
 import ast.ASTNode;
+import context.statics.StaticContext;
+import context.statics.Symbol;
+
 import java.util.*;
 import java.util.*;
 import java.util.*;
@@ -7,22 +10,34 @@ import java.util.*;
 import java.util.List;
 import java.util.Map;
 
-
 public class DeterministicLifetimeAnalyzer {
 
-    private final Map<String, String> varTypes;
-    private final Linearizer linearizer;
+    private final Linearizer linearizer = new Linearizer();
     private final UsageCollector usageCollector;
 
-    public DeterministicLifetimeAnalyzer(Map<String, String> varTypes) {
-        this.varTypes = varTypes;
-        this.linearizer = new Linearizer();
-        this.usageCollector = new UsageCollector(varTypes);
+    public DeterministicLifetimeAnalyzer(StaticContext rootCtx) {
+        Map<String, Symbol> allSymbols = collectAllSymbols(rootCtx);
+        this.usageCollector = new UsageCollector(allSymbols);
     }
 
-    public Map<String, ASTNode> analyzeAndReturnNode(List<ASTNode> roots) {
+    public Map<Symbol, ASTNode> analyze(List<ASTNode> roots) {
         List<ASTNode> linearized = linearizer.collectLinearStatements(roots);
         usageCollector.collect(linearized);
-        return usageCollector.getLastUseNode();
+        return usageCollector.getLastUses();
+    }
+
+    private Map<String, Symbol> collectAllSymbols(StaticContext root) {
+        Map<String, Symbol> map = new LinkedHashMap<>();
+        collectRecursive(root, map);
+        return map;
+    }
+
+    private void collectRecursive(StaticContext ctx, Map<String, Symbol> map) {
+        for (Symbol sym : ctx.getDeclaredVariables()) {
+            map.put(sym.getName(), sym);
+        }
+        for (StaticContext child : ctx.getChildren()) {
+            collectRecursive(child, map);
+        }
     }
 }

--- a/src/memory_manager/lifetime/Linearizer.java
+++ b/src/memory_manager/lifetime/Linearizer.java
@@ -20,7 +20,6 @@ import ast.variables.VariableDeclarationNode;
 import java.util.ArrayList;
 import java.util.List;
 
-
 class Linearizer {
 
     public List<ASTNode> collectLinearStatements(List<ASTNode> roots) {
@@ -37,10 +36,7 @@ class Linearizer {
             return;
         }
 
-        if (node instanceof FunctionNode fn) {
-            out.add(fn); // opcional, você pode ignorar se não quiser trackear funções
-            return;
-        }
+        if (node instanceof FunctionNode fn) return;
 
         if (node instanceof FunctionCallNode call) {
             call.getArgs().forEach(arg -> analyzeNode(arg, out));
@@ -49,16 +45,24 @@ class Linearizer {
         }
 
         if (node instanceof IfNode ifn) {
-            // Não adiciona o IfNode em si
             analyzeNode(ifn.getCondition(), out);
             ifn.getThenBranch().forEach(stmt -> analyzeNode(stmt, out));
-            if (ifn.getElseBranch() != null) ifn.getElseBranch().forEach(stmt -> analyzeNode(stmt, out));
+            if (ifn.getElseBranch() != null)
+                ifn.getElseBranch().forEach(stmt -> analyzeNode(stmt, out));
             return;
         }
 
         if (node instanceof WhileNode wn) {
+
+            out.add(wn);
+            System.out.println("[LINEARIZER] Visitando WhileNode com condição: " + wn.getCondition());
+
             analyzeNode(wn.getCondition(), out);
-            wn.getBody().forEach(stmt -> analyzeNode(stmt, out));
+
+            for (ASTNode stmt : wn.getBody()) {
+                System.out.println("[LINEARIZER] Visitando nó do corpo do While: " + stmt.getClass().getSimpleName());
+                analyzeNode(stmt, out);
+            }
             return;
         }
 

--- a/src/translate/StaticBinder.java
+++ b/src/translate/StaticBinder.java
@@ -5,17 +5,19 @@ import context.statics.StaticContext;
 import context.statics.ScopeKind;
 
 import java.util.List;
-public class StaticBinder {
 
-    public void bind(List<ASTNode> nodes) {
-        StaticContext root = new StaticContext(ScopeKind.GLOBAL);
+public final class StaticBinder {
 
-        for (ASTNode node : nodes) {
-            node.bind(root);
+    private static StaticContext rootContext;
+
+    public void bind(List<ASTNode> ast) {
+        rootContext = new StaticContext(ScopeKind.ROOT);
+        for (ASTNode node : ast) {
+            node.bind(rootContext);
         }
+    }
 
-        System.out.println("========");
-        root.debugPrint(" ");
-        System.out.println("========");
+    public static StaticContext getRootContext() {
+        return rootContext;
     }
 }


### PR DESCRIPTION
- Replaced Map<String, ASTNode> with Map<Symbol, ASTNode> in DeterministicLifetimeAnalyzer and FreePlanner.
- Introduced StaticContext to track scopes, enabling accurate detection of variable lifetimes and last-use nodes.
- Updated UsageCollector to:
    * Resolve Symbols from the node's StaticContext.
    * Consider conditional and loop scopes when marking last use.
- Linearizer enhanced to support WhileNode, IfNode, PrintNode, and list operations, ensuring all relevant nodes are visited.
- FreePlanner adjusted to work with Symbols instead of variable names, preventing issues with shadowed variables or multiple scopes.
- Added debug logging in Linearizer (WhileNode, IfNode, loop bodies, and prints) to trace linearization and last-use calculation.
- FrontendPipeline updated to use the new DeterministicLifetimeAnalyzer API, passing the StaticContext from StaticBinder.
- Integration fixes: OwnershipAnalyzer, FreePlanner, and FreeInsertionPass now operate consistently with Symbols, ensuring correct frees for OWNED variables.
- Result: deterministic variable lifetimes, proper free insertion respecting scope boundaries and escaped variables.

Impact:
- Primitive variables are ignored; lists, structs, and local variables in if/while blocks now have their frees automatically handled.
- Lays the foundation for nested structs and lists within loops and conditionals.