### PR TITLE
fix: correct FreePlanner to insert frees in the correct block

### DIFF
--- a/src/ast/ASTNode.java
+++ b/src/ast/ASTNode.java
@@ -25,10 +25,22 @@ public abstract class ASTNode {
     protected void bindChildren(StaticContext ctx) {
         for (ASTNode child : getChildren()) {
             if (child != null) {
+                child.setParent(this);
                 child.bind(ctx);
             }
         }
     }
+
+
+    private ASTNode parent;
+    public ASTNode getParent() {
+        return parent;
+    }
+
+    public void setParent(ASTNode parent) {
+        this.parent = parent;
+    }
+
 
     public StaticContext getStaticContext() {
         return staticContext;

--- a/src/ast/ifstatements/IfNode.java
+++ b/src/ast/ifstatements/IfNode.java
@@ -93,29 +93,25 @@ public class IfNode extends ASTNode {
         if (elseBranch != null) children.addAll(elseBranch);
         return children;
     }
-
-
     @Override
     protected void bindChildren(StaticContext parent) {
-
-        // condição usa o mesmo escopo
         if (condition != null) {
+            condition.setParent(this);
             condition.bind(parent);
         }
 
-        // then cria escopo condicional
-        StaticContext thenCtx =
-                new StaticContext(ScopeKind.IF_THEN, parent);
-
-        for (ASTNode node : thenBranch) {
-            node.bind(thenCtx);
+        if (thenBranch != null) {
+            StaticContext thenCtx = new StaticContext(ScopeKind.IF_THEN, parent);
+            for (ASTNode node : thenBranch) {
+                node.setParent(this);
+                node.bind(thenCtx);
+            }
         }
 
         if (elseBranch != null) {
-            StaticContext elseCtx =
-                    new StaticContext(ScopeKind.IF_ELSE, parent);
-
+            StaticContext elseCtx = new StaticContext(ScopeKind.IF_ELSE, parent);
             for (ASTNode node : elseBranch) {
+                node.setParent(this);
                 node.bind(elseCtx);
             }
         }

--- a/src/ast/loops/WhileNode.java
+++ b/src/ast/loops/WhileNode.java
@@ -75,15 +75,17 @@ public class WhileNode extends ASTNode {
 
     @Override
     protected void bindChildren(StaticContext parent) {
-
+        condition.setParent(this);
         condition.bind(parent);
 
         StaticContext loopCtx = new StaticContext(ScopeKind.WHILE, parent);
 
         for (ASTNode stmt : body) {
+            stmt.setParent(this);
             stmt.bind(loopCtx);
         }
     }
+
 
     @Override
     public List<ASTNode> getChildren() {

--- a/src/language/main.zd
+++ b/src/language/main.zd
@@ -1,20 +1,59 @@
 main {
 
-int a = 0;
 
-if(a == 0) {
-while(a < 10) {
-    List nomes = ("zard", "ok");
-    print(nomes);
-    a++;
-  }
+function void bubbleSort(List<int> arr) {
+    # Tamanho inicial da lista
+    int n = arr.size();
+    # Laço externo do Bubble Sort
+    for (int i = 0; i < n - 1; i++) {
+
+        # Laço interno (comparações adjacentes)
+        for (int j = 0; j < n - i - 1; j++) {
+
+            # Elementos adjacentes
+            int a = arr.get(j);
+            int b = arr.get(j + 1);
+
+            # Se fora de ordem, trocar
+            if (a > b) {
+
+                # ETAPA 1 — Remover os dois
+
+                arr.remove(j);   # remove a
+                arr.remove(j);   # remove b
+
+                # ETAPA 2 — Lista temporária
+
+                List<int> temp;
+
+                # Copiar elementos antes de j
+                for (int k = 0; k < j; k++) {
+                    temp.add(arr.get(k));
+                }
+
+                # Inserir na ordem correta
+                temp.add(b);
+                temp.add(a);
+
+                # Copiar o restante
+                for (int k = j; k < arr.size(); k++) {
+                    temp.add(arr.get(k));
+                }
+
+                # ETAPA 3 — Substituir arr
+
+                arr.clear();
+
+                for (int k = 0; k < temp.size(); k++) {
+                    arr.add(temp.get(k));
+                }
+            }
+        }
+    }
 }
-else if(a == 2) {
-List te = ("zard", "ok");
-print(te);
-}
 
-
-print("acabou o programa");
+List numeros = (23,13,9,40,80);
+call bubbleSort(numeros);
+print(numeros);
 
 }


### PR DESCRIPTION
- Local variables now have their free inserted at the end of the block where they were declared
- ROOT/Global variables are still freed after their last use, as before
- Fixes LLVM dominance error (Instruction does not dominate all uses)
- Added findBlockEndForDeclaration function to determine the correct insertion point for frees