### PR TITLE
fix(static-context): restrict primitive variable shadowing in loops

### DIFF
--- a/src/language/main.zd
+++ b/src/language/main.zd
@@ -1,22 +1,15 @@
 main {
+    int a = 1;
 
-int a = 0;
+    while(a < 5) {
+        int b = a * 2;   # permitido, loop tem escopo próprio
+        println(b);
 
-if(a == 0) {
-int a = 3;
-println(a);
-while(a < 10) {
-    List nomes = ("zard", "ok");
-    print(nomes);
-    a++;
-  }
-}
-else if(a == 2) {
-List te = ("zard", "ok");
-print(te);
-}
+        while(b < 10) {
+            int a = 0;  # proibido, shadowing do pai
+            b++;
+        }
 
-
-print("acabou o programa");
-
+        a++;
+    }
 }


### PR DESCRIPTION
- Adds a check in StaticContext#declareVariable to identify primitive types (int, double, float, bool, char, string) versus structs/lists/other complex types.
- Prohibits shadowing of primitive variables inside loops or nested blocks, preventing potential infinite recursion or memory misuse.
- Allows shadowing for non-primitives (structs, lists) and in IF/ELSE blocks.
- Maintains normal scoping rules for redeclarations within the same block.